### PR TITLE
Tap controlls for gear shifting.

### DIFF
--- a/Gears/Input/ScriptControls.cpp
+++ b/Gears/Input/ScriptControls.cpp
@@ -263,6 +263,15 @@ bool ScriptControls::ButtonHeld(ControllerControlType control) {
 	return false;
 }
 
+bool ScriptControls::ButtonTapped(ControllerControlType control) {
+	if (!controller.IsConnected())
+		return false;
+	if (controller.WasButtonHeldForMs(controller.StringToButton(ControlXbox[static_cast<int>(control)]), buttonState, 0) &&
+	   !controller.WasButtonHeldForMs(controller.StringToButton(ControlXbox[static_cast<int>(control)]), buttonState, 100))
+		return true;
+	return false;
+}
+
 bool ScriptControls::ButtonIn(ControllerControlType control) {
 	if (!controller.IsConnected())
 		return false;

--- a/Gears/Input/ScriptControls.hpp
+++ b/Gears/Input/ScriptControls.hpp
@@ -122,6 +122,7 @@ public:
 	bool ButtonJustPressed(ControllerControlType control);
 	bool ButtonReleased(ControllerControlType control);
 	bool ButtonHeld(ControllerControlType control);
+	bool ButtonTapped(ControllerControlType control);
 	bool ButtonIn(ControllerControlType control);
 	void SetXboxTrigger(float value);
 	float GetXboxTrigger();

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -6,7 +6,7 @@
 #include "menucontrols.h"
 #include "menu.h"
 #endif
-#include "simpleini/SimpleIni.h"
+#include "../thirdparty/simpleini/SimpleIni.h"
 #include "Util/Logger.hpp"
 #include "Input/keyboard.h"
 #include "Input/ScriptControls.hpp"

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -2,7 +2,7 @@
 #include <Windows.h>
 
 #include <vector>
-#include "simpleini/SimpleIni.h"
+#include "../thirdparty/simpleini/SimpleIni.h"
 
 class Logger;
 class ScriptControls;

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -309,8 +309,13 @@ void update() {
 		}
 	}
 
+	// enum ShiftModes {
+	// 	Sequential = 0,
+	// 	HPattern = 1,
+	// 	Automatic = 2
+	// };
 	// Manual shifting
-	if (settings.ShiftMode == 1) {
+	if (settings.ShiftMode == HPattern) {
 		if (controls.PrevInput == ScriptControls::Wheel) {
 			functionHShiftWheel();
 		}
@@ -318,7 +323,7 @@ void update() {
 			functionHShiftKeyboard();
 		}
 	}
-	else if (settings.ShiftMode == 0){
+	else if (settings.ShiftMode == Sequential){
 		functionSShift();
 		if (settings.AutoGear1) {
 			functionAutoGear1();
@@ -838,7 +843,7 @@ void functionHShiftWheel() {
 
 void functionSShift() {
 	// Shift up
-	if (controls.PrevInput == ScriptControls::Controller	&& controls.ButtonJustPressed(ScriptControls::ControllerControlType::ShiftUp) ||
+	if (controls.PrevInput == ScriptControls::Controller	&& controls.ButtonTapped(ScriptControls::ControllerControlType::ShiftUp) ||
 		controls.PrevInput == ScriptControls::Controller	&& controls.ButtonJustPressed(ScriptControls::LegacyControlType::ShiftUp) ||
 		controls.PrevInput == ScriptControls::Keyboard		&& controls.ButtonJustPressed(ScriptControls::KeyboardControlType::ShiftUp) ||
 		controls.PrevInput == ScriptControls::Wheel			&& controls.ButtonJustPressed(ScriptControls::WheelControlType::ShiftUp)) {
@@ -876,7 +881,7 @@ void functionSShift() {
 
 	// Shift down
 
-	if (controls.PrevInput == ScriptControls::Controller	&& controls.ButtonJustPressed(ScriptControls::ControllerControlType::ShiftDown) ||
+	if (controls.PrevInput == ScriptControls::Controller	&& controls.ButtonTapped(ScriptControls::ControllerControlType::ShiftDown) ||
 		controls.PrevInput == ScriptControls::Controller	&& controls.ButtonJustPressed(ScriptControls::LegacyControlType::ShiftDown) || 
 		controls.PrevInput == ScriptControls::Keyboard		&& controls.ButtonJustPressed(ScriptControls::KeyboardControlType::ShiftDown) ||
 		controls.PrevInput == ScriptControls::Wheel			&& controls.ButtonJustPressed(ScriptControls::WheelControlType::ShiftDown)) {


### PR DESCRIPTION
It struck me that I really wanted to use RB and LB on my XBox360 controller to change gears, but I didn't want to move my Handbrake control.

So I thought: why not make short taps change gears, and anything longer default to the usual GTA handling.

I coded it up, but alas, it throws an exception during load, so I can't test this.

Here it is, anyway.