### PR TITLE
buildscript & includepath fix

### DIFF
--- a/Gears/Gears.vcxproj
+++ b/Gears/Gears.vcxproj
@@ -48,7 +48,7 @@
     <OutDir>bin\</OutDir>
     <IntDir>obj\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(SolutionDir)thirdparty\;$(ProjectDir);..\..\ScriptHookV_SDK;..\..\GTAVMenuBase\;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)thirdparty;../thirdparty;$(ProjectDir);..\..\ScriptHookV_SDK;..\..\GTAVMenuBase;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetExt>.asi</TargetExt>

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,5 @@
+@call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+@echo checking for nuget
+@if exist nuget.exe nuget.exe restore
+set ExternalCompilerOptions=
+msbuild /p:Platform=x64 /p:Configuration=Release /clp:Summary /nologo


### PR DESCRIPTION
for some reason it wouldn't build on my system due to some issue with the thirdparty directory.  I just added a relative version of that path to the project.

I also added a build.bat file for console builds.