### PR TITLE
Implement third party camera mods support via decorators

### DIFF
--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -24,7 +24,7 @@
 #include "Util/Util.hpp"
 #include "Util/Paths.h"
 
-#include "menu.h"
+#include "../GTAVMenuBase/menu.h"
 #include "Memory/NativeMemory.hpp"
 #include "Util/MathExt.h"
 #include "ShiftModes.h"
@@ -38,6 +38,11 @@ const char* decorShiftNotice = "mt_shift_indicator";
 const char* decorFakeNeutral = "mt_neutral";
 const char* decorSetShiftMode = "mt_set_shiftmode";
 const char* decorGetShiftMode = "mt_get_shiftmode";
+
+// Camera mods interoperability (via decorators)
+const char* decorLookingLeft = "mt_looking_left";
+const char* decorLookingRight = "mt_looking_right";
+const char* decorLookingBack = "mt_looking_back";
 
 std::array<float, NUM_GEARS> upshiftSpeedsGame{};
 std::array<float, NUM_GEARS> upshiftSpeedsMod{};
@@ -1866,6 +1871,19 @@ void handleVehicleButtons() {
         vehData.LookBackRShoulder = false;
     }
 
+	// Set camera related decorators
+	DECORATOR::DECOR_SET_BOOL(vehicle, (char *)decorLookingLeft, controls.ButtonIn(ScriptControls::WheelControlType::LookLeft));
+	DECORATOR::DECOR_SET_BOOL(vehicle, (char *)decorLookingRight, controls.ButtonIn(ScriptControls::WheelControlType::LookRight));
+
+	DECORATOR::DECOR_SET_BOOL(vehicle, (char *)decorLookingBack, 
+		controls.ButtonIn(ScriptControls::WheelControlType::LookBack) || 
+		(
+			controls.ButtonIn(ScriptControls::WheelControlType::LookLeft) 
+			&&
+			controls.ButtonIn(ScriptControls::WheelControlType::LookRight)
+		)
+	); // decorLookingBack = LookBack || (LookLeft && LookRight)
+
     if (controls.ButtonJustPressed(ScriptControls::WheelControlType::Camera)) {
         CONTROLS::_SET_CONTROL_NORMAL(0, ControlNextCamera, 1.0f);
     }
@@ -2393,6 +2411,11 @@ bool setupGlobals() {
     registerDecorator(decorFakeNeutral, DECOR_TYPE_INT);
     registerDecorator(decorSetShiftMode, DECOR_TYPE_INT);
     registerDecorator(decorGetShiftMode, DECOR_TYPE_INT);
+
+	// Camera mods interoperability
+	registerDecorator(decorLookingLeft, DECOR_TYPE_BOOL);
+	registerDecorator(decorLookingRight, DECOR_TYPE_BOOL);
+	registerDecorator(decorLookingBack, DECOR_TYPE_BOOL);
 
     *g_bIsDecorRegisterLockedPtr = 1;
     return true;

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -24,7 +24,7 @@
 #include "Util/Util.hpp"
 #include "Util/Paths.h"
 
-#include "../GTAVMenuBase/menu.h"
+#include <menu.h>
 #include "Memory/NativeMemory.hpp"
 #include "Util/MathExt.h"
 #include "ShiftModes.h"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ You can read decorators to get some info about this mod.
 
 Example: ```DECORATOR::DECOR_GET_INT(vehicle, "mt_shift_indicator");``` gets the current shift up/down status. Currently this mod exposes 2 variables which can be used in other scripts.
 
+### Gearbox/Shift mode
+
 Current gear: `mt_gear`
 * `0`: Reverse
 * `1 through 7`: Matching gear
@@ -77,3 +79,19 @@ Set shift mode: `mt_set_shiftmode`
 * `1` - Sequential
 * `2` - H-pattern
 * `3` - Automatic
+
+### Camera (look left/right/back)
+
+These decorators allow custom vehicle camera mods know if user is pressing look-left/right/behind through Manual Transmission's input system (including steering wheel buttons), so they can support this mod easily.
+
+Looking left (bool): `mt_looking_left`
+* `true`  - LookLeft button is pressed
+* `false` - LookLeft button is not pressed
+
+Looking right (bool): `mt_looking_right`
+* `true`  - LookRight button is pressed
+* `false` - LookRight button is not pressed
+
+Looking left (bool): `mt_looking_back`
+* `true`  - LookBack button (or LookLeft + LookRight) is pressed
+* `false` - LookBack button is not pressed


### PR DESCRIPTION
Hi!

I think this will be useful for third party camera mods.
This PR enables third party mods to read if user is pressing look left/back/behind via decorators. 

This is useful for camera mods, so they can read cam-related input without having to deal with XInput/Steering wheels.

[I've already tested this](https://github.com/Rbn3D/CustomCameraVPlus/pull/1) with my Custom Camera V Plus mod and is working fine.

I'll probably upload a video tomorrow showcasing this.
