### PR TITLE
Add support to neutral and reverse gears on DIRT 4 telemetry

### DIFF
--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -1483,7 +1483,7 @@ void update_compatmenu() {
         { "If DashHook is installed, allows lighting the ABS light." });
 
     if (g_menu.BoolOption("Enable UDP telemetry", g_settings.Misc.UDPTelemetry,
-        { "Allows programs like SimHub to use data from this script." })) {
+        { "Allows programs like SimHub to use data from this script. This script uses DIRT 4 format for telemetry data." })) {
         StartUDPTelemetry();
     }
 }

--- a/Gears/UDPTelemetry/UDPTelemetry.cpp
+++ b/Gears/UDPTelemetry/UDPTelemetry.cpp
@@ -3,6 +3,8 @@
 
 #include <inc/natives.h>
 
+extern VehicleGearboxStates g_gearStates;
+
 void UDPTelemetry::UpdatePacket(Socket& socket, Vehicle vehicle, const VehicleData& vehData, 
     const CarControls& controls, VehicleExtensions& ext) {
     TelemetryPacket packet{};
@@ -48,6 +50,11 @@ void UDPTelemetry::UpdatePacket(Socket& socket, Vehicle vehicle, const VehicleDa
     packet.Clutch = controls.ClutchVal;
     packet.Gear = vehData.mGearCurr;
 
+    if (g_gearStates.FakeNeutral) {
+        packet.Gear = 0;
+    } else if (vehData.mGearCurr == 0) {
+        packet.Gear = 10;
+    }
     packet.LateralAcceleration = vehData.mAcceleration.x;
     packet.LongitudinalAcceleration = vehData.mAcceleration.y;
 


### PR DESCRIPTION
This will set the correct values when the car is in neutral and reverse gears when using DIRT 4 on SimHub.

Thanks for your work on all the mods you created. I would most definitely not be playing GTA V if it wasn't for them. 
Also don't know if you changed something but the FFB on 4.7.2 is feeling great. 
Cheers