### PR TITLE
Experimental 'powertrain' based algorithm (TCU)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ packages.config
 Server/
 *.TMP
 doc/changelog.pdf
+/thirdparty/fmt/out/build/x64-Debug

--- a/Gears/ScriptHUD.cpp
+++ b/Gears/ScriptHUD.cpp
@@ -1,6 +1,7 @@
 #include "script.h"
 #include <fmt/format.h>
 #include <inc/natives.h>
+#include <numeric>
 
 #include <menu.h>
 
@@ -415,6 +416,13 @@ void drawDebugInfo() {
             g_gearStates.Shifting ? "~c~" : "", g_gearStates.EngineLoad, g_gearStates.UpshiftLoad));
         showText(0.01, 0.675, 0.3, fmt::format("{}Load/dnReq: {:.3f}\t/{:.3f}",
             g_gearStates.Shifting ? "~c~" : "", g_gearStates.EngineLoad, g_gearStates.DownshiftLoad));
+        showText(0.01, 0.700, 0.3, fmt::format("Using powertrain ratio: {:n}{}", g_gearStates.parsePowertrainRatio(), g_gearStates.isPowertrainRatioTrustworthy() ? "" : "(in training)"));
+        auto wp = g_ext.GetWheelPower(g_playerVehicle);
+        float totalPower = std::accumulate(wp.begin(), wp.end(), 0.0f);
+        totalPower = totalPower / g_vehData.mWheelCount;
+        float currGearRatio = g_vehData.mGearRatios[g_vehData.mGearCurr];
+        showText(0.01, 0.725, 0.3, fmt::format("Current powertrain ratio: {:n}", totalPower / currGearRatio));
+        showText(0.01, 0.750, 0.3, fmt::format("Powertrain training threshold: {:n}", g_gearStates.parsePowertrainRatioThreshold()));
     }
 
     showText(0.85, 0.050, 0.4, fmt::format("Throttle:\t{:.3f}", g_controls.ThrottleVal) , 4);
@@ -539,14 +547,16 @@ void drawVehicleWheelInfo() {
                 //fmt::format("Health: \t{:.3f}", wheelsHealt[i]),
                 fmt::format("Power: \t{:.3f}", wheelsPower[i]),
                 fmt::format("Brake: \t{:.3f}", wheelsBrake[i]),
-                fmt::format("{}ABS~w~ | {}TSC~w~ | {}ESP{}", 
+                fmt::format("{}ABS~w~ {}TCS~w~ {}GRD~w~ {}ESC{}",
                     g_vehData.mWheelsAbs[i] ? "~r~" : "",
                     g_vehData.mWheelsTcs[i] ? "~r~" : "",
+                    g_vehData.mWheelsOnGround[i] ? "" : "~r~",
                     g_vehData.mWheelsEspO[i] || g_vehData.mWheelsEspU[i] ? "~r~" : "",
-                    g_vehData.mWheelsEspO[i] && g_vehData.mWheelsEspU[i] ? "_O+U" 
-                        : g_vehData.mWheelsEspO[i] ? "_O" 
-                        : g_vehData.mWheelsEspU[i] ? "_U" : "")
-                }, 
+                    g_vehData.mWheelsEspO[i] && g_vehData.mWheelsEspU[i] ? "_O+U"
+                        : g_vehData.mWheelsEspO[i] ? "_O"
+                        : g_vehData.mWheelsEspU[i] ? "_U" : ""
+                    )
+            },
             color);
         GRAPHICS::DRAW_LINE(wheelCoords[i].x, wheelCoords[i].y, wheelCoords[i].z,
             wheelCoords[i].x, wheelCoords[i].y, wheelCoords[i].z + 1.0f + 2.5f * wheelsCompr[i], 255, 0, 0, 255);

--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -532,6 +532,7 @@ void update_finetuneautooptionsmenu() {
     g_menu.FloatOption("Economy rate", g_settings.AutoParams.EcoRate, 0.01f, 0.50f, 0.01f,
         { "On releasing throttle, high values cause earlier upshifts.",
           "Set this low to stay in gear longer when releasing throttle." });
+    g_menu.BoolOption("Using new TCU", g_settings.AutoParams.UsingNewTCU, { "Using experimental new Transmission Control Unit" });
 }
 
 std::vector<std::string> formatVehicleConfig(const VehicleConfig& config) {

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -264,6 +264,7 @@ void ScriptSettings::SaveGeneral() const {
     ini.SetDoubleValue("AUTO_PARAMS", "CurrGearMinRPM", AutoParams.CurrGearMinRPM);
     ini.SetDoubleValue("AUTO_PARAMS", "EcoRate", AutoParams.EcoRate);
     ini.SetDoubleValue("AUTO_PARAMS", "DownshiftTimeoutMult", AutoParams.DownshiftTimeoutMult);
+    ini.SetDoubleValue("AUTO_PARAMS", "UsingNewTCU", AutoParams.UsingNewTCU);
 
     // [HUD]
     ini.SetBoolValue("HUD", "EnableHUD", HUD.Enable);

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -136,6 +136,8 @@ public:
         float EcoRate = 0.05f;
         // Timeout mult for not downshifting after an upshift
         float DownshiftTimeoutMult = 1.0f;
+        // Experimental new tcu
+        bool UsingNewTCU = false;
     } AutoParams;
 
     // [CUSTOM_STEERING]

--- a/Gears/VehicleData.hpp
+++ b/Gears/VehicleData.hpp
@@ -72,6 +72,16 @@ struct VehicleGearboxStates {
     float EngineLoad = 0.0f;
     float UpshiftLoad = 0.0f;
     float DownshiftLoad = 0.0f;
+
+    // TCU stuff
+    std::vector<float> PowertrainHistoryDistribution = { 0.000123f };
+    int PowertrainHistorySize = 120;
+    int PowertrainSecondCounter = 0;
+    int PowertrainTimer = 0;
+    float parsePowertrainRatioThreshold();
+    float parsePowertrainRatio();
+    void updatePowertrainRatioDistribution(float ratio);
+    bool isPowertrainRatioTrustworthy();
 };
 
 struct WheelPatchStates {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ GTA V Manual Transmission
 =========================
 [![Build status](https://ci.appveyor.com/api/projects/status/gy6yh17lp5l1k48d?svg=true)](https://ci.appveyor.com/project/E66666666/gtavmanualtransmission) [![GitHub total downloads](https://img.shields.io/github/downloads/E66666666/GTAVManualTransmission/total.svg?label=downloads&logo=GitHub)](https://github.com/E66666666/GTAVManualTransmission/releases) [![Discord](https://img.shields.io/discord/499483293679353861.svg?logo=discord)](https://discord.gg/gHee23U)
 
+Nyconing's Fork
+  * Faster Automatic 
+
+
 This mod for Grand Theft Auto V enables manual transmission and offers various gearbox modes:
   * Sequential 
   * H-pattern


### PR DESCRIPTION
**Using new TCU**
introduce 'powertrain' based algorithm:

- ratio between gear ratio and wheels power output are always constant, this ratio named 'powertrain ratio'
- this ratio effected by vehicle engine, throttle and brakes
- it also effected while vehicle in collision included bump
- this algorithm predicts next gear 's wheels power output, and then shift up when current output drop below next gear 's wheels power output

added 'using experimental TCU' in automatic fine tuning menu (default off)
(original automatic algorithm remains unchanged)
added debug info for TCU
also fixed abbreviation naming and added GRD (grounded) into wheel's debug info