### PR TITLE
Feature/fix control settings menu

### DIFF
--- a/Gears/Constants.h
+++ b/Gears/Constants.h
@@ -3,8 +3,8 @@
 #define STR(x) STR_HELPER(x)
 
 #define VERSION_MAJOR 4
-#define VERSION_MINOR 7
-#define VERSION_PATCH 2
+#define VERSION_MINOR 8
+#define VERSION_PATCH 0
 
 namespace Constants {
     static const char* const DisplayVersion = "v" STR(VERSION_MAJOR) "."  STR(VERSION_MINOR) "." STR(VERSION_PATCH);

--- a/Gears/Input/CarControls.cpp
+++ b/Gears/Input/CarControls.cpp
@@ -304,39 +304,39 @@ bool CarControls::ButtonReleasedAfter(LegacyControlType control, int time) {
  */
 
 bool CarControls::ButtonJustPressed(WheelControlType control) {
-    if (!mWheelInput.IsConnected(WheelButtonGUIDs[static_cast<int>(control)]) ||
-        WheelButton[static_cast<int>(control)] == -1) {
+    if (!mWheelInput.IsConnected(WheelButton[static_cast<int>(control)].Guid) ||
+        WheelButton[static_cast<int>(control)].Control == -1) {
         return false;
     }
-    return mWheelInput.IsButtonJustPressed(WheelButton[static_cast<int>(control)],
-                                           WheelButtonGUIDs[static_cast<int>(control)]);
+    return mWheelInput.IsButtonJustPressed(WheelButton[static_cast<int>(control)].Control,
+                                           WheelButton[static_cast<int>(control)].Guid);
 }
 
 bool CarControls::ButtonReleased(WheelControlType control) {
-    if (!mWheelInput.IsConnected(WheelButtonGUIDs[static_cast<int>(control)]) ||
-        WheelButton[static_cast<int>(control)] == -1) {
+    if (!mWheelInput.IsConnected(WheelButton[static_cast<int>(control)].Guid) ||
+        WheelButton[static_cast<int>(control)].Control == -1) {
         return false;
     }
-    return mWheelInput.IsButtonJustReleased(WheelButton[static_cast<int>(control)],
-                                            WheelButtonGUIDs[static_cast<int>(control)]);
+    return mWheelInput.IsButtonJustReleased(WheelButton[static_cast<int>(control)].Control,
+                                            WheelButton[static_cast<int>(control)].Guid);
 }
 
 bool CarControls::ButtonHeld(WheelControlType control, int delay) {
-    if (!mWheelInput.IsConnected(WheelButtonGUIDs[static_cast<int>(control)]) ||
-        WheelButton[static_cast<int>(control)] == -1) {
+    if (!mWheelInput.IsConnected(WheelButton[static_cast<int>(control)].Guid) ||
+        WheelButton[static_cast<int>(control)].Control == -1) {
         return false;
     }
-    return mWheelInput.WasButtonHeldForMs(WheelButton[static_cast<int>(control)],
-                                          WheelButtonGUIDs[static_cast<int>(control)], delay);
+    return mWheelInput.WasButtonHeldForMs(WheelButton[static_cast<int>(control)].Control,
+                                          WheelButton[static_cast<int>(control)].Guid, delay);
 }
 
 bool CarControls::ButtonIn(WheelControlType control) {
-    if (!mWheelInput.IsConnected(WheelButtonGUIDs[static_cast<int>(control)]) ||
-        WheelButton[static_cast<int>(control)] == -1) {
+    if (!mWheelInput.IsConnected(WheelButton[static_cast<int>(control)].Guid) ||
+        WheelButton[static_cast<int>(control)].Control == -1) {
         return false;
     }
-    return mWheelInput.IsButtonPressed(WheelButton[static_cast<int>(control)],
-                                       WheelButtonGUIDs[static_cast<int>(control)]);
+    return mWheelInput.IsButtonPressed(WheelButton[static_cast<int>(control)].Control,
+                                       WheelButton[static_cast<int>(control)].Guid);
 }
 
 void CarControls::CheckCustomButtons() {

--- a/Gears/Input/CarControls.cpp
+++ b/Gears/Input/CarControls.cpp
@@ -37,9 +37,9 @@ void CarControls::InitFFB() {
 }
 
 void CarControls::updateKeyboard() {
-    ThrottleVal = IsKeyPressed(KBControl[static_cast<int>(KeyboardControlType::Throttle)]) ? 1.0f : 0.0f;
-    BrakeVal = IsKeyPressed(KBControl[static_cast<int>(KeyboardControlType::Brake)]) ? 1.0f : 0.0f;
-    ClutchVal = IsKeyPressed(KBControl[static_cast<int>(KeyboardControlType::Clutch)]) ? 1.0f : 0.0f;
+    ThrottleVal = IsKeyPressed(KBControl[static_cast<int>(KeyboardControlType::Throttle)].Control) ? 1.0f : 0.0f;
+    BrakeVal = IsKeyPressed(KBControl[static_cast<int>(KeyboardControlType::Brake)].Control) ? 1.0f : 0.0f;
+    ClutchVal = IsKeyPressed(KBControl[static_cast<int>(KeyboardControlType::Clutch)].Control) ? 1.0f : 0.0f;
 }
 
 void CarControls::updateController() {
@@ -144,10 +144,10 @@ void CarControls::UpdateValues(InputDevices prevInput, bool skipKeyboardInput) {
 CarControls::InputDevices CarControls::GetLastInputDevice(InputDevices previousInput, bool enableWheel) {
     auto kbThrottleIdx = static_cast<int>(KeyboardControlType::Throttle);
     auto kbBrakeIdx = static_cast<int>(KeyboardControlType::Brake);
-    if (IsKeyJustPressed(KBControl[kbThrottleIdx], KeyboardControlType::Throttle) ||
-        IsKeyPressed(KBControl[kbThrottleIdx]) ||
-        IsKeyJustPressed(KBControl[kbBrakeIdx], KeyboardControlType::Brake) ||
-        IsKeyPressed(KBControl[kbBrakeIdx])) {
+    if (IsKeyJustPressed(KBControl[kbThrottleIdx].Control, KeyboardControlType::Throttle) ||
+        IsKeyPressed(KBControl[kbThrottleIdx].Control) ||
+        IsKeyJustPressed(KBControl[kbBrakeIdx].Control, KeyboardControlType::Brake) ||
+        IsKeyPressed(KBControl[kbBrakeIdx].Control)) {
         return Keyboard;
     }
 
@@ -214,7 +214,7 @@ bool CarControls::IsKeyJustPressed(int key, KeyboardControlType control) {
 }
 
 bool CarControls::ButtonJustPressed(KeyboardControlType control) {
-    return IsKeyJustPressed(KBControl[static_cast<int>(control)], control);
+    return IsKeyJustPressed(KBControl[static_cast<int>(control)].Control, control);
 }
 
 /*

--- a/Gears/Input/CarControls.cpp
+++ b/Gears/Input/CarControls.cpp
@@ -29,10 +29,9 @@ void CarControls::InitWheel() {
 void CarControls::InitFFB() {
 
     auto steerGUID = WheelAxes[static_cast<int>(WheelAxisType::Steer)].Guid;
-    auto steerAxis = mWheelInput.StringToAxis(WheelAxes[static_cast<int>(WheelAxisType::Steer)].Control);
     auto ffAxis = mWheelInput.StringToAxis(WheelAxes[static_cast<int>(WheelAxisType::ForceFeedback)].Control);
 
-    if (mWheelInput.InitFFB(steerGUID, steerAxis)) {
+    if (mWheelInput.InitFFB(steerGUID, ffAxis)) {
         mWheelInput.UpdateCenterSteering(steerGUID, ffAxis);
     }
 }

--- a/Gears/Input/CarControls.cpp
+++ b/Gears/Input/CarControls.cpp
@@ -44,13 +44,13 @@ void CarControls::updateKeyboard() {
 
 void CarControls::updateController() {
     if (g_settings.Controller.Native.Enable) {
-        ThrottleVal = mNativeController.GetAnalogValue(mNativeController.EControlToButton(LegacyControls[static_cast<int>(LegacyControlType::Throttle)]));
-        BrakeVal = mNativeController.GetAnalogValue(mNativeController.EControlToButton(LegacyControls[static_cast<int>(LegacyControlType::Brake)]));
-        ClutchVal = mNativeController.GetAnalogValue(mNativeController.EControlToButton(LegacyControls[static_cast<int>(LegacyControlType::Clutch)]));
+        ThrottleVal = mNativeController.GetAnalogValue(LegacyControls[static_cast<int>(LegacyControlType::Throttle)].Control);
+        BrakeVal = mNativeController.GetAnalogValue(LegacyControls[static_cast<int>(LegacyControlType::Brake)].Control);
+        ClutchVal = mNativeController.GetAnalogValue(LegacyControls[static_cast<int>(LegacyControlType::Clutch)].Control);
     } else {
-        ThrottleVal = mXInputController.GetAnalogValue(mXInputController.StringToButton(ControlXbox[static_cast<int>(ControllerControlType::Throttle)]));
-        BrakeVal = mXInputController.GetAnalogValue(mXInputController.StringToButton(ControlXbox[static_cast<int>(ControllerControlType::Brake)]));
-        ClutchVal = mXInputController.GetAnalogValue(mXInputController.StringToButton(ControlXbox[static_cast<int>(ControllerControlType::Clutch)]));
+        ThrottleVal = mXInputController.GetAnalogValue(mXInputController.StringToButton(ControlXbox[static_cast<int>(ControllerControlType::Throttle)].Control));
+        BrakeVal = mXInputController.GetAnalogValue(mXInputController.StringToButton(ControlXbox[static_cast<int>(ControllerControlType::Brake)].Control));
+        ClutchVal = mXInputController.GetAnalogValue(mXInputController.StringToButton(ControlXbox[static_cast<int>(ControllerControlType::Clutch)].Control));
     }
 }
 
@@ -153,9 +153,9 @@ CarControls::InputDevices CarControls::GetLastInputDevice(InputDevices previousI
 
     if (g_settings.Controller.Native.Enable) {
         auto lcThrottleIdx = static_cast<int>(LegacyControlType::Throttle);
-        auto lcThrottleBtn = mNativeController.EControlToButton(LegacyControls[lcThrottleIdx]);
+        auto lcThrottleBtn = LegacyControls[lcThrottleIdx].Control;
         auto lcBrakeIdx = static_cast<int>(LegacyControlType::Brake);
-        auto lcBrakeBtn = mNativeController.EControlToButton(LegacyControls[lcBrakeIdx]);
+        auto lcBrakeBtn = LegacyControls[lcBrakeIdx].Control;
         if (mNativeController.IsButtonJustPressed(lcThrottleBtn) ||
             mNativeController.IsButtonPressed(lcThrottleBtn) ||
             mNativeController.IsButtonJustPressed(lcBrakeBtn) ||
@@ -165,9 +165,9 @@ CarControls::InputDevices CarControls::GetLastInputDevice(InputDevices previousI
     } 
     else {
         auto cThrottleIdx = static_cast<int>(ControllerControlType::Throttle);
-        auto cThrottleBtn = mXInputController.StringToButton(ControlXbox[cThrottleIdx]);
+        auto cThrottleBtn = mXInputController.StringToButton(ControlXbox[cThrottleIdx].Control);
         auto cBrakeIdx = static_cast<int>(ControllerControlType::Brake);
-        auto cBrakeBtn = mXInputController.StringToButton(ControlXbox[cBrakeIdx]);
+        auto cBrakeBtn = mXInputController.StringToButton(ControlXbox[cBrakeIdx].Control);
         if (mXInputController.IsButtonJustPressed(cThrottleBtn) ||
             mXInputController.IsButtonPressed(cThrottleBtn) ||
             mXInputController.IsButtonJustPressed(cBrakeBtn) ||
@@ -223,78 +223,78 @@ bool CarControls::ButtonJustPressed(KeyboardControlType control) {
 
 bool CarControls::ButtonJustPressed(ControllerControlType control) {
     return mXInputController.IsButtonJustPressed(
-        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]));
+        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control));
 }
 
 bool CarControls::ButtonReleased(ControllerControlType control) {
     return mXInputController.IsButtonJustReleased(
-        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]));
+        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control));
 }
 
 bool CarControls::ButtonReleasedAfter(ControllerControlType control, int time) {
     return mXInputController.WasButtonHeldForMs(
-        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]), time);
+        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control), time);
 }
 
 bool CarControls::ButtonHeld(ControllerControlType control) {
     return mXInputController.WasButtonHeldForMs(
-        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]), g_settings.Controller.HoldTimeMs);
+        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control), g_settings.Controller.HoldTimeMs);
 }
 
 bool CarControls::ButtonHeldOver(ControllerControlType control, int millis) {
     return mXInputController.WasButtonHeldOverMs(
-        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]), millis);
+        mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control), millis);
 }
 
 XInputController::TapState CarControls::ButtonTapped(ControllerControlType control) {
-    return mXInputController.WasButtonTapped(mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]), g_settings.Controller.MaxTapTimeMs);
+    return mXInputController.WasButtonTapped(mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control), g_settings.Controller.MaxTapTimeMs);
 }
 
 bool CarControls::ButtonIn(ControllerControlType control) {
-    return mXInputController.IsButtonPressed(mXInputController.StringToButton(ControlXbox[static_cast<int>(control)]));
+    return mXInputController.IsButtonPressed(mXInputController.StringToButton(ControlXbox[static_cast<int>(control)].Control));
 }
 
 /*
- * Legacy stuff
+ * Native stuff
  */
 bool CarControls::ButtonJustPressed(LegacyControlType control) {
     if (!g_settings.Controller.Native.Enable) return false;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.IsButtonJustPressed(gameButton);
 }
 bool CarControls::ButtonReleased(LegacyControlType control) {
     if (!g_settings.Controller.Native.Enable) return false;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.IsButtonJustReleased(gameButton);
 }
 
 bool CarControls::ButtonHeld(LegacyControlType control) {
     if (!g_settings.Controller.Native.Enable) return false;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.WasButtonHeldForMs(gameButton, g_settings.Controller.HoldTimeMs);
 }
 
 bool CarControls::ButtonHeldOver(LegacyControlType control, int millis) {
     if (!g_settings.Controller.Native.Enable) return false;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.WasButtonHeldOverMs(gameButton, millis);
 }
 
 bool CarControls::ButtonIn(LegacyControlType control) {
     if (!g_settings.Controller.Native.Enable) return false;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.IsButtonPressed(gameButton);
 }
 
 NativeController::TapState CarControls::ButtonTapped(LegacyControlType control) {
     if (!g_settings.Controller.Native.Enable) return NativeController::TapState::ButtonUp;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.WasButtonTapped(gameButton, g_settings.Controller.MaxTapTimeMs);
 }
 
 bool CarControls::ButtonReleasedAfter(LegacyControlType control, int time) {
     if (!g_settings.Controller.Native.Enable) return false;
-    auto gameButton = mNativeController.EControlToButton(LegacyControls[static_cast<int>(control)]);
+    auto gameButton = LegacyControls[static_cast<int>(control)].Control;
     return mNativeController.WasButtonHeldForMs(gameButton, time);
 }
 

--- a/Gears/Input/CarControls.hpp
+++ b/Gears/Input/CarControls.hpp
@@ -141,6 +141,16 @@ public:
         std::string Name;
     };
 
+    struct SKeyboardInput {
+        SKeyboardInput() = default;
+        SKeyboardInput(std::string configTag, int control, std::string name)
+            : ConfigTag(std::move(configTag)), Control(control), Name(std::move(name)) {}
+
+        std::string ConfigTag;
+        int Control = -1;
+        std::string Name;
+    };
+
     const std::vector<std::pair<std::string, int>> LegacyControlsMap = {
         { "ControlFrontendDown",		187 },
         { "ControlFrontendUp",			188 },
@@ -228,24 +238,13 @@ public:
     float SteerValRaw = 0.0f;   // For readout purposes. SteerVal is used for gameplay.
     float HandbrakeVal = 0.0f;
 
-    //int ThrottleMin = 0;
-    //int ThrottleMax = 0;
-    //int BrakeMin = 0;
-    //int BrakeMax = 0;
-    //int ClutchMin = 0;
-    //int ClutchMax = 0;
-    //int SteerMin = 0;
-    //int SteerMax = 0;
-    //int HandbrakeMax = 0;
-    //int HandbrakeMin = 0;
-
     std::array<std::string, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXbox = {};
     std::array<int, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXboxBlocks = {};
 
     std::array<int, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> LegacyControls = {};
     std::array<int, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> ControlNativeBlocks = {};
 
-    std::array<int, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
+    std::array<SKeyboardInput, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
 
     std::array<SWheelInput<std::string>, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxes = {};
 
@@ -259,31 +258,6 @@ public:
 
     XInputController& GetController() {
         return mXInputController;
-    }
-
-    int ConfTagKB2key(const std::string &confTag) {
-        if (confTag == "Toggle") return KBControl[static_cast<int>(KeyboardControlType::Toggle)];
-        if (confTag == "ToggleH") return KBControl[static_cast<int>(KeyboardControlType::ToggleH)];
-        if (confTag == "ShiftUp") return KBControl[static_cast<int>(KeyboardControlType::ShiftUp)];
-        if (confTag == "ShiftDown") return KBControl[static_cast<int>(KeyboardControlType::ShiftDown)];
-        if (confTag == "Clutch") return KBControl[static_cast<int>(KeyboardControlType::Clutch)];
-        if (confTag == "Engine") return KBControl[static_cast<int>(KeyboardControlType::Engine)];
-        if (confTag == "Throttle") return KBControl[static_cast<int>(KeyboardControlType::Throttle)];
-        if (confTag == "Brake") return KBControl[static_cast<int>(KeyboardControlType::Brake)];
-        if (confTag == "HR") return KBControl[static_cast<int>(KeyboardControlType::HR)];
-        if (confTag == "H1") return KBControl[static_cast<int>(KeyboardControlType::H1)];
-        if (confTag == "H2") return KBControl[static_cast<int>(KeyboardControlType::H2)];
-        if (confTag == "H3") return KBControl[static_cast<int>(KeyboardControlType::H3)];
-        if (confTag == "H4") return KBControl[static_cast<int>(KeyboardControlType::H4)];
-        if (confTag == "H5") return KBControl[static_cast<int>(KeyboardControlType::H5)];
-        if (confTag == "H6") return KBControl[static_cast<int>(KeyboardControlType::H6)];
-        if (confTag == "H7") return KBControl[static_cast<int>(KeyboardControlType::H7)];
-        if (confTag == "H8") return KBControl[static_cast<int>(KeyboardControlType::H8)];
-        if (confTag == "H9") return KBControl[static_cast<int>(KeyboardControlType::H9)];
-        if (confTag == "H10") return KBControl[static_cast<int>(KeyboardControlType::H10)];
-        if (confTag == "HN") return KBControl[static_cast<int>(KeyboardControlType::HN)];
-        if (confTag == "SwitchAssist") return KBControl[static_cast<int>(KeyboardControlType::CycleAssists)];
-        return -1;
     }
 
     std::string ConfTagController2Value(const std::string &confTag) {

--- a/Gears/Input/CarControls.hpp
+++ b/Gears/Input/CarControls.hpp
@@ -232,9 +232,23 @@ public:
     std::array<int, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> ControlNativeBlocks = {};
 
     std::array<int, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
-    
-    std::array<std::string, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxes = {};
-    std::array<GUID, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxesGUIDs = {};
+
+    template <typename TControl>
+    struct SWheelInput {
+        SWheelInput()
+            : Guid({}), Control({}) {}
+
+        SWheelInput(GUID guid, TControl control, std::string name, std::string configTag)
+            : Guid(guid), Control(control), Name(std::move(name)), ConfigTag(std::move(configTag)) {}
+
+        GUID Guid;
+        TControl Control;
+        std::string Name;
+        std::string ConfigTag;
+    };
+
+    std::array<SWheelInput<std::string>, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxes = {};
+
     std::array<int, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButton = {};
     std::array<GUID, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButtonGUIDs = {};
     std::array<int, MAX_RGBBUTTONS> WheelToKey = {};

--- a/Gears/Input/CarControls.hpp
+++ b/Gears/Input/CarControls.hpp
@@ -24,7 +24,7 @@ public:
         Toggle,
         ToggleH,
         Engine,
-        SwitchAssist,
+        CycleAssists,
         SIZEOF_ControllerControlType
     };
 
@@ -37,7 +37,7 @@ public:
         Toggle,
         ToggleH,
         Engine,
-        SwitchAssist,
+        CycleAssists,
         SIZEOF_LegacyControlType
     };
 
@@ -62,7 +62,7 @@ public:
         Engine,
         Toggle,
         ToggleH,
-        SwitchAssist,
+        CycleAssists,
         SIZEOF_KeyboardControlType
     };
 
@@ -103,7 +103,10 @@ public:
         AReverse,
         ANeutral,
         ADrive,
-        SwitchAssist,
+        CycleAssists,
+        ToggleABS,
+        ToggleESC,
+        ToggleTCS,
         UNKNOWN,
         SIZEOF_WheelControlType
     };
@@ -265,7 +268,7 @@ public:
         if (confTag == "H9") return KBControl[static_cast<int>(KeyboardControlType::H9)];
         if (confTag == "H10") return KBControl[static_cast<int>(KeyboardControlType::H10)];
         if (confTag == "HN") return KBControl[static_cast<int>(KeyboardControlType::HN)];
-        if (confTag == "SwitchAssist") return KBControl[static_cast<int>(KeyboardControlType::SwitchAssist)];
+        if (confTag == "SwitchAssist") return KBControl[static_cast<int>(KeyboardControlType::CycleAssists)];
         return -1;
     }
 
@@ -278,7 +281,7 @@ public:
         if (confTag == "Engine") return ControlXbox[static_cast<int>(ControllerControlType::Engine)];
         if (confTag == "Throttle") return ControlXbox[static_cast<int>(ControllerControlType::Throttle)];
         if (confTag == "Brake") return ControlXbox[static_cast<int>(ControllerControlType::Brake)];
-        if (confTag == "SwitchAssist") return ControlXbox[static_cast<int>(ControllerControlType::SwitchAssist)];
+        if (confTag == "SwitchAssist") return ControlXbox[static_cast<int>(ControllerControlType::CycleAssists)];
 
         return "UNKNOWN";
     }
@@ -292,7 +295,7 @@ public:
         if (confTag == "Engine")		return LegacyControls[static_cast<int>(LegacyControlType::Engine)];
         if (confTag == "Throttle")		return LegacyControls[static_cast<int>(LegacyControlType::Throttle)];
         if (confTag == "Brake")			return LegacyControls[static_cast<int>(LegacyControlType::Brake)];
-        if (confTag == "SwitchAssist")	return LegacyControls[static_cast<int>(LegacyControlType::SwitchAssist)];
+        if (confTag == "SwitchAssist")	return LegacyControls[static_cast<int>(LegacyControlType::CycleAssists)];
 
         return -1;
     }
@@ -327,7 +330,7 @@ public:
         if (confTag == "INDICATOR_LEFT"		) return WheelButton[static_cast<int>(WheelControlType::IndicatorLeft)];
         if (confTag == "INDICATOR_RIGHT"	) return WheelButton[static_cast<int>(WheelControlType::IndicatorRight)];
         if (confTag == "INDICATOR_HAZARD") return WheelButton[static_cast<int>(WheelControlType::IndicatorHazard)];
-        if (confTag == "SWITCH_ASSIST") return WheelButton[static_cast<int>(WheelControlType::SwitchAssist)];
+        if (confTag == "CYCLE_ASSISTS") return WheelButton[static_cast<int>(WheelControlType::CycleAssists)];
 
         return -1;
     }

--- a/Gears/Input/CarControls.hpp
+++ b/Gears/Input/CarControls.hpp
@@ -127,6 +127,20 @@ public:
         Wheel = 2
     };
 
+    template <typename TControl>
+    struct SWheelInput {
+        SWheelInput()
+            : Guid({}), Control() {}
+
+        SWheelInput(std::string configTag, GUID guid, TControl control, std::string name)
+            : ConfigTag(std::move(configTag)), Guid(guid), Control(control), Name(std::move(name)) {}
+
+        std::string ConfigTag;
+        GUID Guid;
+        TControl Control;
+        std::string Name;
+    };
+
     const std::vector<std::pair<std::string, int>> LegacyControlsMap = {
         { "ControlFrontendDown",		187 },
         { "ControlFrontendUp",			188 },
@@ -233,24 +247,10 @@ public:
 
     std::array<int, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
 
-    template <typename TControl>
-    struct SWheelInput {
-        SWheelInput()
-            : Guid({}), Control({}) {}
-
-        SWheelInput(GUID guid, TControl control, std::string name, std::string configTag)
-            : Guid(guid), Control(control), Name(std::move(name)), ConfigTag(std::move(configTag)) {}
-
-        GUID Guid;
-        TControl Control;
-        std::string Name;
-        std::string ConfigTag;
-    };
-
     std::array<SWheelInput<std::string>, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxes = {};
 
-    std::array<int, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButton = {};
-    std::array<GUID, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButtonGUIDs = {};
+    std::array<SWheelInput<int>, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButton = {};
+
     std::array<int, MAX_RGBBUTTONS> WheelToKey = {};
 
     GUID WheelToKeyGUID = {};
@@ -321,32 +321,6 @@ public:
             }
         }
         return std::to_string(nativeControl);
-    }
-
-    int ConfTagWheel2Value(const std::string &confTag) {
-        if (confTag == "TOGGLE_MOD"			) return WheelButton[static_cast<int>(WheelControlType::Toggle)];
-        if (confTag == "CHANGE_SHIFTMODE"	) return WheelButton[static_cast<int>(WheelControlType::ToggleH)];
-        if (confTag == "THROTTLE_BUTTON") return WheelButton[static_cast<int>(WheelControlType::Throttle)];
-        if (confTag == "BRAKE_BUTTON") return WheelButton[static_cast<int>(WheelControlType::Brake)];
-        if (confTag == "CLUTCH_BUTTON"		) return WheelButton[static_cast<int>(WheelControlType::Clutch)];
-        if (confTag == "SHIFT_UP"			) return WheelButton[static_cast<int>(WheelControlType::ShiftUp)];
-        if (confTag == "SHIFT_DOWN"			) return WheelButton[static_cast<int>(WheelControlType::ShiftDown)];
-        if (confTag == "ENGINE"				) return WheelButton[static_cast<int>(WheelControlType::Engine)];
-        if (confTag == "HANDBRAKE"			) return WheelButton[static_cast<int>(WheelControlType::Handbrake)];
-        if (confTag == "HORN"				) return WheelButton[static_cast<int>(WheelControlType::Horn)];
-        if (confTag == "LIGHTS"				) return WheelButton[static_cast<int>(WheelControlType::Lights)];
-        if (confTag == "LOOK_BACK"			) return WheelButton[static_cast<int>(WheelControlType::LookBack)];
-        if (confTag == "LOOK_LEFT"			) return WheelButton[static_cast<int>(WheelControlType::LookLeft)];
-        if (confTag == "LOOK_RIGHT"			) return WheelButton[static_cast<int>(WheelControlType::LookRight)];
-        if (confTag == "CHANGE_CAMERA"		) return WheelButton[static_cast<int>(WheelControlType::Camera)];
-        if (confTag == "RADIO_NEXT"			) return WheelButton[static_cast<int>(WheelControlType::RadioNext)];
-        if (confTag == "RADIO_PREVIOUS"		) return WheelButton[static_cast<int>(WheelControlType::RadioPrev)];
-        if (confTag == "INDICATOR_LEFT"		) return WheelButton[static_cast<int>(WheelControlType::IndicatorLeft)];
-        if (confTag == "INDICATOR_RIGHT"	) return WheelButton[static_cast<int>(WheelControlType::IndicatorRight)];
-        if (confTag == "INDICATOR_HAZARD") return WheelButton[static_cast<int>(WheelControlType::IndicatorHazard)];
-        if (confTag == "CYCLE_ASSISTS") return WheelButton[static_cast<int>(WheelControlType::CycleAssists)];
-
-        return -1;
     }
 
 private:

--- a/Gears/Input/CarControls.hpp
+++ b/Gears/Input/CarControls.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include <string>
 #include <utility>
 
@@ -151,32 +152,20 @@ public:
         std::string Name;
     };
 
-    const std::vector<std::pair<std::string, int>> LegacyControlsMap = {
-        { "ControlFrontendDown",		187 },
-        { "ControlFrontendUp",			188 },
-        { "ControlFrontendLeft",		189 },
-        { "ControlFrontendRight",		190 },
-        { "ControlFrontendRdown",		191 },
-        { "ControlFrontendRup",			192 },
-        { "ControlFrontendRleft",		193 },
-        { "ControlFrontendRright",		194 },
-        { "ControlFrontendAxisX",		195 },
-        { "ControlFrontendAxisY",		196 },
-        { "ControlFrontendRightAxisX",	197 },
-        { "ControlFrontendRightAxisY",	198 },
-        { "ControlFrontendPause",		199 },
-        { "ControlFrontendAccept",		201 },
-        { "ControlFrontendCancel",		202 },
-        { "ControlFrontendX",			203 },
-        { "ControlFrontendY",			204 },
-        { "ControlFrontendLb",			205 },
-        { "ControlFrontendRb",			206 },
-        { "ControlFrontendLt",			207 },
-        { "ControlFrontendRt",			208 },
-        { "ControlFrontendLs",			209 },
-        { "ControlFrontendRs",			210 },
-        { "ControlFrontendDelete",		214 },
-        { "ControlFrontendSelect",		217 },
+    template <typename TControl>
+    struct SControllerInput {
+        SControllerInput() = default;
+
+        SControllerInput(std::string configTag, TControl control, std::string name, std::string description)
+            : ConfigTag(std::move(configTag))
+            , Control(control)
+            , Name(std::move(name))
+            , Description(std::move(description)) {}
+
+        std::string ConfigTag;
+        TControl Control;
+        std::string Name;
+        std::string Description;
     };
 
     CarControls();
@@ -238,10 +227,10 @@ public:
     float SteerValRaw = 0.0f;   // For readout purposes. SteerVal is used for gameplay.
     float HandbrakeVal = 0.0f;
 
-    std::array<std::string, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXbox = {};
+    std::array<SControllerInput<std::string>, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXbox = {};
     std::array<int, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXboxBlocks = {};
 
-    std::array<int, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> LegacyControls = {};
+    std::array<SControllerInput<eControl>, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> LegacyControls = {};
     std::array<int, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> ControlNativeBlocks = {};
 
     std::array<SKeyboardInput, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
@@ -258,43 +247,6 @@ public:
 
     XInputController& GetController() {
         return mXInputController;
-    }
-
-    std::string ConfTagController2Value(const std::string &confTag) {
-        if (confTag == "Toggle") return ControlXbox[static_cast<int>(ControllerControlType::Toggle)];
-        if (confTag == "ToggleShift") return ControlXbox[static_cast<int>(ControllerControlType::ToggleH)];
-        if (confTag == "ShiftUp") return ControlXbox[static_cast<int>(ControllerControlType::ShiftUp)];
-        if (confTag == "ShiftDown") return ControlXbox[static_cast<int>(ControllerControlType::ShiftDown)];
-        if (confTag == "Clutch") return ControlXbox[static_cast<int>(ControllerControlType::Clutch)];
-        if (confTag == "Engine") return ControlXbox[static_cast<int>(ControllerControlType::Engine)];
-        if (confTag == "Throttle") return ControlXbox[static_cast<int>(ControllerControlType::Throttle)];
-        if (confTag == "Brake") return ControlXbox[static_cast<int>(ControllerControlType::Brake)];
-        if (confTag == "SwitchAssist") return ControlXbox[static_cast<int>(ControllerControlType::CycleAssists)];
-
-        return "UNKNOWN";
-    }
-
-    int ConfTagLController2Value(const std::string &confTag) {
-        if (confTag == "Toggle")		return LegacyControls[static_cast<int>(LegacyControlType::Toggle)];
-        if (confTag == "ToggleShift")	return LegacyControls[static_cast<int>(LegacyControlType::ToggleH)];
-        if (confTag == "ShiftUp")		return LegacyControls[static_cast<int>(LegacyControlType::ShiftUp)];
-        if (confTag == "ShiftDown")		return LegacyControls[static_cast<int>(LegacyControlType::ShiftDown)];
-        if (confTag == "Clutch")		return LegacyControls[static_cast<int>(LegacyControlType::Clutch)];
-        if (confTag == "Engine")		return LegacyControls[static_cast<int>(LegacyControlType::Engine)];
-        if (confTag == "Throttle")		return LegacyControls[static_cast<int>(LegacyControlType::Throttle)];
-        if (confTag == "Brake")			return LegacyControls[static_cast<int>(LegacyControlType::Brake)];
-        if (confTag == "SwitchAssist")	return LegacyControls[static_cast<int>(LegacyControlType::CycleAssists)];
-
-        return -1;
-    }
-
-    std::string NativeControl2Text(int nativeControl) const {
-        for (const auto& mapItem : LegacyControlsMap) {
-            if (mapItem.second == nativeControl) {
-                return mapItem.first;
-            }
-        }
-        return std::to_string(nativeControl);
     }
 
 private:

--- a/Gears/Input/CarControls.hpp
+++ b/Gears/Input/CarControls.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <map>
 #include <string>
 #include <utility>
 
@@ -129,40 +128,19 @@ public:
     };
 
     template <typename TControl>
-    struct SWheelInput {
-        SWheelInput()
+    struct SInput {
+        SInput()
             : Guid({}), Control() {}
 
-        SWheelInput(std::string configTag, GUID guid, TControl control, std::string name)
-            : ConfigTag(std::move(configTag)), Guid(guid), Control(control), Name(std::move(name)) {}
-
-        std::string ConfigTag;
-        GUID Guid;
-        TControl Control;
-        std::string Name;
-    };
-
-    struct SKeyboardInput {
-        SKeyboardInput() = default;
-        SKeyboardInput(std::string configTag, int control, std::string name)
-            : ConfigTag(std::move(configTag)), Control(control), Name(std::move(name)) {}
-
-        std::string ConfigTag;
-        int Control = -1;
-        std::string Name;
-    };
-
-    template <typename TControl>
-    struct SControllerInput {
-        SControllerInput() = default;
-
-        SControllerInput(std::string configTag, TControl control, std::string name, std::string description)
+        SInput(std::string configTag, GUID guid, TControl control, std::string name, std::string description)
             : ConfigTag(std::move(configTag))
+            , Guid(guid)
             , Control(control)
             , Name(std::move(name))
             , Description(std::move(description)) {}
 
         std::string ConfigTag;
+        GUID Guid;
         TControl Control;
         std::string Name;
         std::string Description;
@@ -227,17 +205,17 @@ public:
     float SteerValRaw = 0.0f;   // For readout purposes. SteerVal is used for gameplay.
     float HandbrakeVal = 0.0f;
 
-    std::array<SControllerInput<std::string>, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXbox = {};
+    std::array<SInput<std::string>, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXbox = {};
     std::array<int, static_cast<int>(ControllerControlType::SIZEOF_ControllerControlType)> ControlXboxBlocks = {};
 
-    std::array<SControllerInput<eControl>, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> LegacyControls = {};
+    std::array<SInput<eControl>, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> LegacyControls = {};
     std::array<int, static_cast<int>(LegacyControlType::SIZEOF_LegacyControlType)> ControlNativeBlocks = {};
 
-    std::array<SKeyboardInput, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
+    std::array<SInput<int>, static_cast<int>(KeyboardControlType::SIZEOF_KeyboardControlType)> KBControl = {};
 
-    std::array<SWheelInput<std::string>, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxes = {};
+    std::array<SInput<std::string>, static_cast<int>(WheelAxisType::SIZEOF_WheelAxisType)> WheelAxes = {};
 
-    std::array<SWheelInput<int>, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButton = {};
+    std::array<SInput<int>, static_cast<int>(WheelControlType::SIZEOF_WheelControlType)> WheelButton = {};
 
     std::array<int, MAX_RGBBUTTONS> WheelToKey = {};
 

--- a/Gears/Input/NativeController.h
+++ b/Gears/Input/NativeController.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <inc/enums.h>
 
-#include <vector>
-#include <map>
+#include <unordered_map>
 #include <stdexcept>
 #include <string>
 
@@ -15,7 +14,7 @@ public:
         Tapped
     };
 
-    static inline const std::map<eControl, std::string> NativeGamepadInputs = {
+    static inline const std::unordered_map<eControl, std::string> NativeGamepadInputs = {
         { ControlFrontendDown      , "Dpad down" },
         { ControlFrontendUp        , "Dpad up" },
         { ControlFrontendLeft      , "Dpad left" },
@@ -63,11 +62,11 @@ public:
     }
 
 private:
-    std::map<eControl, __int64> pressTime;
-    std::map<eControl, __int64> releaseTime;
-    std::map<eControl, __int64> tapPressTime;
-    std::map<eControl, __int64> tapReleaseTime;
-    std::map<eControl, bool> gameButtonCurr;
-    std::map<eControl, bool> gameButtonPrev;
+    std::unordered_map<eControl, __int64> pressTime;
+    std::unordered_map<eControl, __int64> releaseTime;
+    std::unordered_map<eControl, __int64> tapPressTime;
+    std::unordered_map<eControl, __int64> tapReleaseTime;
+    std::unordered_map<eControl, bool> gameButtonCurr;
+    std::unordered_map<eControl, bool> gameButtonPrev;
 };
 

--- a/Gears/Input/NativeController.h
+++ b/Gears/Input/NativeController.h
@@ -1,6 +1,10 @@
 #pragma once
-#include <array>
 #include <inc/enums.h>
+
+#include <vector>
+#include <map>
+#include <stdexcept>
+#include <string>
 
 class NativeController
 {
@@ -11,85 +15,59 @@ public:
         Tapped
     };
 
-    enum GameButtons {
-        ControlFrontendDown		 ,
-        ControlFrontendUp		 ,
-        ControlFrontendLeft		 ,
-        ControlFrontendRight	 ,
-        ControlFrontendRdown	 ,
-        ControlFrontendRup		 ,
-        ControlFrontendRleft	 ,
-        ControlFrontendRright	 ,
-        ControlFrontendAxisX	 ,
-        ControlFrontendAxisY	 ,
-        ControlFrontendRightAxisX,
-        ControlFrontendRightAxisY,
-        ControlFrontendPause	 ,
-        ControlFrontendAccept	 ,
-        ControlFrontendCancel	 ,
-        ControlFrontendX		 ,
-        ControlFrontendY		 ,
-        ControlFrontendLb		 ,
-        ControlFrontendRb		 ,
-        ControlFrontendLt		 ,
-        ControlFrontendRt		 ,
-        ControlFrontendLs		 ,
-        ControlFrontendRs		 ,
-        ControlFrontendDelete	 ,
-        ControlFrontendSelect	 ,
-        UNKNOWN,
-        SIZEOF_GameButtons
-    };
-
-    std::array<int, SIZEOF_GameButtons> GameEnums = {
-        eControl::ControlFrontendDown		,
-        eControl::ControlFrontendUp			,
-        eControl::ControlFrontendLeft		,
-        eControl::ControlFrontendRight		,
-        eControl::ControlFrontendRdown		,
-        eControl::ControlFrontendRup		,
-        eControl::ControlFrontendRleft		,
-        eControl::ControlFrontendRright		,
-        eControl::ControlFrontendAxisX		,
-        eControl::ControlFrontendAxisY		,
-        eControl::ControlFrontendRightAxisX	,
-        eControl::ControlFrontendRightAxisY	,
-        eControl::ControlFrontendPause		,
-        eControl::ControlFrontendAccept		,
-        eControl::ControlFrontendCancel		,
-        eControl::ControlFrontendX			,
-        eControl::ControlFrontendY			,
-        eControl::ControlFrontendLb			,
-        eControl::ControlFrontendRb			,
-        eControl::ControlFrontendLt			,
-        eControl::ControlFrontendRt			,
-        eControl::ControlFrontendLs			,
-        eControl::ControlFrontendRs			,
-        eControl::ControlFrontendDelete		,
-        eControl::ControlFrontendSelect		,
-        -1 // UNKNOWN
+    static inline const std::map<eControl, std::string> NativeGamepadInputs = {
+        { ControlFrontendDown      , "Dpad down" },
+        { ControlFrontendUp        , "Dpad up" },
+        { ControlFrontendLeft      , "Dpad left" },
+        { ControlFrontendRight     , "Dpad right" },
+        { ControlFrontendAxisX     , "Left stick X" },
+        { ControlFrontendAxisY     , "Left stick Y" },
+        { ControlFrontendRightAxisX, "Right stick X" },
+        { ControlFrontendRightAxisY, "Right stick Y" },
+        { ControlFrontendPause     , "Start" },
+        { ControlFrontendAccept    , "A" },
+        { ControlFrontendCancel    , "B" },
+        { ControlFrontendX         , "X" },
+        { ControlFrontendY         , "Y" },
+        { ControlFrontendLb        , "Left shoulder" },
+        { ControlFrontendRb        , "Right shoulder" },
+        { ControlFrontendLt        , "Left trigger" },
+        { ControlFrontendRt        , "Right trigger" },
+        { ControlFrontendLs        , "Left stick click" },
+        { ControlFrontendRs        , "Right stick click" },
+        { ControlFrontendSelect    , "Select" },
     };
 
     NativeController();
-    ~NativeController();
 
-    bool IsButtonPressed(GameButtons gameButton);
-    bool IsButtonJustPressed(GameButtons gameButton);
-    bool IsButtonJustReleased(GameButtons gameButton);
-    bool WasButtonHeldForMs(GameButtons gameButton, int milliseconds);
-    bool WasButtonHeldOverMs(GameButtons gameButton, int milliseconds);
-    TapState WasButtonTapped(GameButtons gameButton, int milliseconds);
+    bool IsButtonPressed(eControl gameButton);
+    bool IsButtonJustPressed(eControl gameButton);
+    bool IsButtonJustReleased(eControl gameButton);
+    bool WasButtonHeldForMs(eControl gameButton, int milliseconds);
+    bool WasButtonHeldOverMs(eControl gameButton, int milliseconds);
+    TapState WasButtonTapped(eControl gameButton, int milliseconds);
     void Update();
 
-    float GetAnalogValue(GameButtons gameButton);
-    GameButtons EControlToButton(int eControlItem);
+    float GetAnalogValue(eControl gameButton);
+
+    static std::string GetControlName(int control) {
+        if (control == -1)
+            return "None";
+
+        try {
+            return NativeGamepadInputs.at(static_cast<eControl>(control));
+        }
+        catch (std::out_of_range&) {
+            return "Unknown input type";
+        }
+    }
 
 private:
-    std::array<__int64, SIZEOF_GameButtons> pressTime;
-    std::array<__int64, SIZEOF_GameButtons> releaseTime;
-    std::array<__int64, SIZEOF_GameButtons> tapPressTime;
-    std::array<__int64, SIZEOF_GameButtons> tapReleaseTime;
-    std::array<bool, SIZEOF_GameButtons> gameButtonCurr;
-    std::array<bool, SIZEOF_GameButtons> gameButtonPrev;
+    std::map<eControl, __int64> pressTime;
+    std::map<eControl, __int64> releaseTime;
+    std::map<eControl, __int64> tapPressTime;
+    std::map<eControl, __int64> tapReleaseTime;
+    std::map<eControl, bool> gameButtonCurr;
+    std::map<eControl, bool> gameButtonPrev;
 };
 

--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -121,7 +121,7 @@ namespace {
         { CarControls::WheelControlType::IndicatorHazard, "[IndicatorHazard]" },
         { CarControls::WheelControlType::Toggle         , "[ToggleMod]" },
         { CarControls::WheelControlType::ToggleH        , "[ChangeShiftMode]" },
-        { CarControls::WheelControlType::SwitchAssist   , "[SwitchAssist]" },
+        { CarControls::WheelControlType::CycleAssists   , "[SwitchAssist]" },
     };
 
     const std::vector<SFont> fonts {

--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -1709,9 +1709,6 @@ void saveAxis(const std::string &confTag, GUID devGUID, const std::string& axis,
     std::string devName = StrUtil::utf8_encode(wDevName);
     auto index = g_settings.SteeringAppendDevice(devGUID, devName);
     g_settings.SteeringSaveAxis(confTag, index, axis, min, max);
-    if (confTag == "STEER") {
-        g_settings.SteeringSaveFFBAxis(confTag, index, axis);
-    }
     g_settings.Read(&g_controls);
 }
 

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -921,7 +921,7 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
 
     // [CLUTCH]
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Clutch)] =
-        parseWheelItem<std::string>(ini, "Clutch", "");
+        parseWheelItem<std::string>(ini, "CLUTCH", "");
     Wheel.Clutch.Min = ini.GetLongValue("CLUTCH", "MIN", -1);
     Wheel.Clutch.Max = ini.GetLongValue("CLUTCH", "MAX", -1);
 

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -890,12 +890,18 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
         ini.GetLongValue("CYCLE_ASSISTS", "BUTTON", -1);
 
     // [STEER]
-    scriptControl->WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Steer)] =
-        DeviceIndexToGUID(ini.GetLongValue("STEER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Steer)] =
-        ini.GetValue("STEER", "AXLE", "");
+        CarControls::SWheelInput<std::string>(
+            DeviceIndexToGUID(ini.GetLongValue("STEER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue("STEER", "AXLE", ""),
+            "Steer", "STEER");
+
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::ForceFeedback)] =
-        ini.GetValue("STEER", "FFB", "");
+        CarControls::SWheelInput<std::string>(
+            DeviceIndexToGUID(ini.GetLongValue("STEER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue("STEER", "FFB", ""),
+            "FFB", "FFB");
+
     Wheel.Steering.Min = ini.GetLongValue("STEER", "MIN", -1);
     Wheel.Steering.Max = ini.GetLongValue("STEER", "MAX", -1);
 
@@ -911,38 +917,42 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
     Wheel.Steering.SteerMult = ini.GetDoubleValue("STEER", "GameSteerMultWheel", Wheel.Steering.SteerMult);
 
     // [THROTTLE]
-    scriptControl->WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Throttle)] =
-        DeviceIndexToGUID(ini.GetLongValue("THROTTLE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Throttle)] =
-        ini.GetValue("THROTTLE", "AXLE", "");
+        CarControls::SWheelInput<std::string>(
+            DeviceIndexToGUID(ini.GetLongValue("THROTTLE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue("THROTTLE", "AXLE", ""),
+            "Throttle", "THROTTLE");
     Wheel.Throttle.Min = ini.GetLongValue("THROTTLE", "MIN", -1);
     Wheel.Throttle.Max = ini.GetLongValue("THROTTLE", "MAX", -1);
     Wheel.Throttle.AntiDeadZone = ini.GetDoubleValue("THROTTLE", "ANTIDEADZONE", 0.25);
     Wheel.Throttle.Gamma = ini.GetDoubleValue("THROTTLE", "GAMMA", 1.0);
 
     // [BRAKE]
-    scriptControl->WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Brake)] =
-        DeviceIndexToGUID(ini.GetLongValue("BRAKE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Brake)] =
-        ini.GetValue("BRAKE", "AXLE", "");
+        CarControls::SWheelInput<std::string>(
+            DeviceIndexToGUID(ini.GetLongValue("BRAKE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue("BRAKE", "AXLE", ""),
+            "Brake", "BRAKE");
     Wheel.Brake.Min = ini.GetLongValue("BRAKE", "MIN", -1);
     Wheel.Brake.Max = ini.GetLongValue("BRAKE", "MAX", -1);
     Wheel.Brake.AntiDeadZone = ini.GetDoubleValue("BRAKE", "ANTIDEADZONE", 0.25);
     Wheel.Brake.Gamma = ini.GetDoubleValue("BRAKE", "GAMMA", 1.0);
 
     // [CLUTCH]
-    scriptControl->WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Clutch)] =
-        DeviceIndexToGUID(ini.GetLongValue("CLUTCH", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Clutch)] =
-        ini.GetValue("CLUTCH", "AXLE", "");
+        CarControls::SWheelInput<std::string>(
+            DeviceIndexToGUID(ini.GetLongValue("CLUTCH", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue("CLUTCH", "AXLE", ""),
+            "Clutch", "CLUTCH");
     Wheel.Clutch.Min = ini.GetLongValue("CLUTCH", "MIN", -1);
     Wheel.Clutch.Max = ini.GetLongValue("CLUTCH", "MAX", -1);
 
     // [HANDBRAKE_ANALOG]
-    scriptControl->WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Handbrake)] =
-        DeviceIndexToGUID(ini.GetLongValue("HANDBRAKE_ANALOG", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Handbrake)] =
-        ini.GetValue("HANDBRAKE_ANALOG", "AXLE", "");
+        CarControls::SWheelInput<std::string>(
+            DeviceIndexToGUID(ini.GetLongValue("HANDBRAKE_ANALOG", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue("HANDBRAKE_ANALOG", "AXLE", ""),
+            "Handbrake (Analog)", "HANDBRAKE_ANALOG");
     Wheel.HandbrakeA.Min = ini.GetLongValue("HANDBRAKE_ANALOG", "MIN", -1);
     Wheel.HandbrakeA.Max = ini.GetLongValue("HANDBRAKE_ANALOG", "MAX", -1);
 

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -746,8 +746,8 @@ void ScriptSettings::parseSettingsControls(CarControls* scriptControl) {
         ini.GetValue("CONTROLLER", "Toggle", "UNKNOWN");
     scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ToggleH)] =
         ini.GetValue("CONTROLLER", "ToggleShift", "B");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::SwitchAssist)] = 
-        ini.GetValue("CONTROLLER", "SwitchAssist", "UNKNOWN");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::CycleAssists)] = 
+        ini.GetValue("CONTROLLER", "CycleAssists", "UNKNOWN");
 
     Controller.BlockCarControls = ini.GetBoolValue("CONTROLLER", "BlockCarControls", Controller.BlockCarControls);
     Controller.IgnoreShiftsUI = ini.GetBoolValue("CONTROLLER", "IgnoreShiftsUI", Controller.IgnoreShiftsUI);
@@ -776,7 +776,7 @@ void ScriptSettings::parseSettingsControls(CarControls* scriptControl) {
 
     scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Toggle)] = ini.GetLongValue("CONTROLLER_NATIVE", "Toggle", -1);
     scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ToggleH)] = ini.GetLongValue("CONTROLLER_NATIVE", "ToggleShift", ControlFrontendCancel);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::SwitchAssist)] = ini.GetLongValue("CONTROLLER_NATIVE", "SwitchAssist", -1);
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::CycleAssists)] = ini.GetLongValue("CONTROLLER_NATIVE", "CycleAssists", -1);
     scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ShiftUp)] = ini.GetLongValue("CONTROLLER_NATIVE", "ShiftUp", ControlFrontendAccept);
     scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ShiftDown)] = ini.GetLongValue("CONTROLLER_NATIVE", "ShiftDown", ControlFrontendX);
     scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Clutch)] = ini.GetLongValue("CONTROLLER_NATIVE", "Clutch", ControlFrontendAxisY);
@@ -791,7 +791,7 @@ void ScriptSettings::parseSettingsControls(CarControls* scriptControl) {
     // [KEYBOARD]
     scriptControl->KBControl[static_cast<int>(CarControls::KeyboardControlType::Toggle)] = str2key(ini.GetValue("KEYBOARD", "Toggle", "VK_OEM_5"));
     scriptControl->KBControl[static_cast<int>(CarControls::KeyboardControlType::ToggleH)] = str2key(ini.GetValue("KEYBOARD", "ToggleH", "VK_OEM_6"));
-    scriptControl->KBControl[static_cast<int>(CarControls::KeyboardControlType::SwitchAssist)] = str2key(ini.GetValue("KEYBOARD", "SwitchAssist", "UNKNOWN"));
+    scriptControl->KBControl[static_cast<int>(CarControls::KeyboardControlType::CycleAssists)] = str2key(ini.GetValue("KEYBOARD", "CycleAssists", "UNKNOWN"));
 
     scriptControl->KBControl[static_cast<int>(CarControls::KeyboardControlType::ShiftUp)] = str2key(ini.GetValue("KEYBOARD", "ShiftUp", "LSHIFT"));
     scriptControl->KBControl[static_cast<int>(CarControls::KeyboardControlType::ShiftDown)] = str2key(ini.GetValue("KEYBOARD", "ShiftDown", "LCTRL"));
@@ -883,11 +883,11 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ToggleH)] =
         ini.GetLongValue("CHANGE_SHIFTMODE", "BUTTON", -1);
 
-    // [SWITCH_ASSIST]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::SwitchAssist)] =
-        DeviceIndexToGUID(ini.GetLongValue("SWITCH_ASSIST", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::SwitchAssist)] =
-        ini.GetLongValue("SWITCH_ASSIST", "BUTTON", -1);
+    // [CYCLE_ASSISTS]
+    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::CycleAssists)] =
+        DeviceIndexToGUID(ini.GetLongValue("CYCLE_ASSISTS", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
+    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::CycleAssists)] =
+        ini.GetLongValue("CYCLE_ASSISTS", "BUTTON", -1);
 
     // [STEER]
     scriptControl->WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Steer)] =

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -759,14 +759,6 @@ void ScriptSettings::parseSettingsControls(CarControls* scriptControl) {
     CHECK_LOG_SI_ERROR(result, "load");
 
     // [CONTROLLER]
-    // TODO: Fix this somehow
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Toggle)] =
-        ini.GetValue("CONTROLLER", "Toggle", "UNKNOWN");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ToggleH)] =
-        ini.GetValue("CONTROLLER", "ToggleShift", "B");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::CycleAssists)] = 
-        ini.GetValue("CONTROLLER", "CycleAssists", "UNKNOWN");
-
     Controller.BlockCarControls = ini.GetBoolValue("CONTROLLER", "BlockCarControls", Controller.BlockCarControls);
     Controller.IgnoreShiftsUI = ini.GetBoolValue("CONTROLLER", "IgnoreShiftsUI", Controller.IgnoreShiftsUI);
     Controller.BlockHShift = ini.GetBoolValue("CONTROLLER", "BlockHShift", Controller.BlockHShift);
@@ -777,30 +769,34 @@ void ScriptSettings::parseSettingsControls(CarControls* scriptControl) {
 
     Controller.ToggleEngine = ini.GetBoolValue("CONTROLLER", "ToggleEngine", Controller.ToggleEngine);
 
-    // TODO: Also this
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ShiftUp)] = ini.GetValue("CONTROLLER", "ShiftUp", "A");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ShiftDown)] = ini.GetValue("CONTROLLER", "ShiftDown", "X");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Clutch)] = ini.GetValue("CONTROLLER", "Clutch", "LeftThumbUp");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Engine)] = ini.GetValue("CONTROLLER", "Engine", "DpadDown");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Throttle)] = ini.GetValue("CONTROLLER", "Throttle", "RightTrigger");
-    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Brake)] = ini.GetValue("CONTROLLER", "Brake", "LeftTrigger");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Toggle)] = parseControllerItem<std::string>(ini, "Toggle", "UNKNOWN", "Toggle MT", "Usage: hold");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ToggleH)] = parseControllerItem<std::string>(ini, "ToggleShift", "B", "Change shift mode", "Usage: hold");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::CycleAssists)] = parseControllerItem<std::string>(ini, "CycleAssists", "UNKNOWN", "Cycle assists", "Usage: hold");
 
-    scriptControl->ControlXboxBlocks[static_cast<int>(CarControls::ControllerControlType::ShiftUp)] = ini.GetLongValue("CONTROLLER", "ShiftUpBlocks", -1);
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ShiftUp)] =   parseControllerItem<std::string>(ini, "ShiftUp", "A", "Shift up", "Usage: tap");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::ShiftDown)] = parseControllerItem<std::string>(ini, "ShiftDown", "X", "Shift down", "Usage: tap");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Engine)] =    parseControllerItem<std::string>(ini, "Engine", "DpadDown", "Engine", "Usage: hold");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Throttle)] =  parseControllerItem<std::string>(ini, "Throttle", "RightTrigger", "Throttle", "Usage: analog");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Brake)] =     parseControllerItem<std::string>(ini, "Brake", "LeftTrigger", "Brake", "Usage: analog");
+    scriptControl->ControlXbox[static_cast<int>(CarControls::ControllerControlType::Clutch)] =    parseControllerItem<std::string>(ini, "Clutch", "LeftThumbUp", "Clutch", "Usage: hold/analog");
+
+    scriptControl->ControlXboxBlocks[static_cast<int>(CarControls::ControllerControlType::ShiftUp)] =   ini.GetLongValue("CONTROLLER", "ShiftUpBlocks", -1);
     scriptControl->ControlXboxBlocks[static_cast<int>(CarControls::ControllerControlType::ShiftDown)] = ini.GetLongValue("CONTROLLER", "ShiftDownBlocks", -1);
-    scriptControl->ControlXboxBlocks[static_cast<int>(CarControls::ControllerControlType::Clutch)] = ini.GetLongValue("CONTROLLER", "ClutchBlocks", -1);
+    scriptControl->ControlXboxBlocks[static_cast<int>(CarControls::ControllerControlType::Clutch)] =    ini.GetLongValue("CONTROLLER", "ClutchBlocks", -1);
 
     // [CONTROLLER_NATIVE]
     Controller.Native.Enable = ini.GetBoolValue("CONTROLLER_NATIVE", "Enable", Controller.Native.Enable);
 
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Toggle)] = ini.GetLongValue("CONTROLLER_NATIVE", "Toggle", -1);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ToggleH)] = ini.GetLongValue("CONTROLLER_NATIVE", "ToggleShift", ControlFrontendCancel);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::CycleAssists)] = ini.GetLongValue("CONTROLLER_NATIVE", "CycleAssists", -1);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ShiftUp)] = ini.GetLongValue("CONTROLLER_NATIVE", "ShiftUp", ControlFrontendAccept);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ShiftDown)] = ini.GetLongValue("CONTROLLER_NATIVE", "ShiftDown", ControlFrontendX);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Clutch)] = ini.GetLongValue("CONTROLLER_NATIVE", "Clutch", ControlFrontendAxisY);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Engine)] = ini.GetLongValue("CONTROLLER_NATIVE", "Engine", ControlFrontendDown);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Throttle)] = ini.GetLongValue("CONTROLLER_NATIVE", "Throttle", ControlFrontendRt);
-    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Brake)] = ini.GetLongValue("CONTROLLER_NATIVE", "Brake", ControlFrontendLt);
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Toggle)] =       parseControllerItem<eControl>(ini, "Toggle", static_cast<eControl>(-1), "Toggle MT", "Usage: hold");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ToggleH)] =      parseControllerItem<eControl>(ini, "ToggleShift", ControlFrontendCancel, "Change shift mode", "Usage: hold");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::CycleAssists)] = parseControllerItem<eControl>(ini, "CycleAssists", static_cast<eControl>(-1), "Cycle assists", "Usage: hold");
+
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ShiftUp)] =   parseControllerItem<eControl>(ini, "ShiftUp", ControlFrontendAccept, "Shift up", "Usage: tap");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::ShiftDown)] = parseControllerItem<eControl>(ini, "ShiftDown", ControlFrontendX   , "Shift down", "Usage: tap");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Engine)] =    parseControllerItem<eControl>(ini, "Engine", ControlFrontendDown   , "Engine", "Usage: hold");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Throttle)] =  parseControllerItem<eControl>(ini, "Throttle", ControlFrontendRt   , "Throttle", "Usage: analog");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Brake)] =     parseControllerItem<eControl>(ini, "Brake", ControlFrontendLt      , "Brake", "Usage: analog");
+    scriptControl->LegacyControls[static_cast<int>(CarControls::LegacyControlType::Clutch)] =    parseControllerItem<eControl>(ini, "Clutch", ControlFrontendAxisY  , "Clutch", "Usage: hold/analog");
 
     scriptControl->ControlNativeBlocks[static_cast<int>(CarControls::LegacyControlType::ShiftUp)] =   ini.GetLongValue("CONTROLLER_NATIVE", "ShiftUpBlocks", -1)  ;
     scriptControl->ControlNativeBlocks[static_cast<int>(CarControls::LegacyControlType::ShiftDown)] = ini.GetLongValue("CONTROLLER_NATIVE", "ShiftDownBlocks", -1);
@@ -1249,6 +1245,23 @@ CarControls::SWheelInput<T> ScriptSettings::parseWheelItem(CSimpleIniA& ini, con
 CarControls::SKeyboardInput ScriptSettings::parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name) {
     std::string nameFmt = formatInputName(key, name);
     return CarControls::SKeyboardInput(key, str2key(ini.GetValue("KEYBOARD", key, default)), nameFmt);
+}
+
+template <typename T>
+CarControls::SControllerInput<T> ScriptSettings::parseControllerItem(CSimpleIniA& ini, const char* key, T default, const char* name, const char* description) {
+    if constexpr (std::is_same<T, eControl>::value) {
+        return CarControls::SControllerInput<T>(key,
+            static_cast<T>(ini.GetLongValue("CONTROLLER_NATIVE", key, static_cast<int>(default))),
+            name, description);
+    }
+    else if constexpr (std::is_same<T, std::string>::value) {
+        return CarControls::SControllerInput<T>(key,
+            ini.GetValue("CONTROLLER", key, default.c_str()),
+            name, description);
+    }
+    else {
+        static_assert(false, "Type must be string or eControl.");
+    }
 }
 
 #pragma warning(pop)

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -872,35 +872,25 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
     nDevices = it;
 
     // [TOGGLE_MOD]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Toggle)] =
-        DeviceIndexToGUID(ini.GetLongValue("TOGGLE_MOD", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Toggle)] =
-        ini.GetLongValue("TOGGLE_MOD", "BUTTON", -1);
+        parseWheelItem<int>(ini, "TOGGLE_MOD", -1, "Toggle MT");
 
     // [CHANGE_SHIFTMODE]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::ToggleH)] =
-        DeviceIndexToGUID(ini.GetLongValue("CHANGE_SHIFTMODE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ToggleH)] =
-        ini.GetLongValue("CHANGE_SHIFTMODE", "BUTTON", -1);
-
-    // [CYCLE_ASSISTS]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::CycleAssists)] =
-        DeviceIndexToGUID(ini.GetLongValue("CYCLE_ASSISTS", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::CycleAssists)] =
-        ini.GetLongValue("CYCLE_ASSISTS", "BUTTON", -1);
+        parseWheelItem<int>(ini, "CHANGE_SHIFTMODE", -1, "Change shift mode");
 
     // [STEER]
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Steer)] =
-        CarControls::SWheelInput<std::string>(
+        CarControls::SWheelInput<std::string>("STEER",
             DeviceIndexToGUID(ini.GetLongValue("STEER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("STEER", "AXLE", ""),
-            "Steer", "STEER");
+            "Steer");
 
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::ForceFeedback)] =
-        CarControls::SWheelInput<std::string>(
+        CarControls::SWheelInput<std::string>("FFB",
             DeviceIndexToGUID(ini.GetLongValue("STEER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("STEER", "FFB", ""),
-            "FFB", "FFB");
+            "FFB");
 
     Wheel.Steering.Min = ini.GetLongValue("STEER", "MIN", -1);
     Wheel.Steering.Max = ini.GetLongValue("STEER", "MAX", -1);
@@ -918,10 +908,10 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
 
     // [THROTTLE]
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Throttle)] =
-        CarControls::SWheelInput<std::string>(
+        CarControls::SWheelInput<std::string>("THROTTLE",
             DeviceIndexToGUID(ini.GetLongValue("THROTTLE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("THROTTLE", "AXLE", ""),
-            "Throttle", "THROTTLE");
+            "Throttle");
     Wheel.Throttle.Min = ini.GetLongValue("THROTTLE", "MIN", -1);
     Wheel.Throttle.Max = ini.GetLongValue("THROTTLE", "MAX", -1);
     Wheel.Throttle.AntiDeadZone = ini.GetDoubleValue("THROTTLE", "ANTIDEADZONE", 0.25);
@@ -929,10 +919,10 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
 
     // [BRAKE]
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Brake)] =
-        CarControls::SWheelInput<std::string>(
+        CarControls::SWheelInput<std::string>("BRAKE",
             DeviceIndexToGUID(ini.GetLongValue("BRAKE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("BRAKE", "AXLE", ""),
-            "Brake", "BRAKE");
+            "Brake");
     Wheel.Brake.Min = ini.GetLongValue("BRAKE", "MIN", -1);
     Wheel.Brake.Max = ini.GetLongValue("BRAKE", "MAX", -1);
     Wheel.Brake.AntiDeadZone = ini.GetDoubleValue("BRAKE", "ANTIDEADZONE", 0.25);
@@ -940,190 +930,136 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
 
     // [CLUTCH]
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Clutch)] =
-        CarControls::SWheelInput<std::string>(
+        CarControls::SWheelInput<std::string>("CLUTCH",
             DeviceIndexToGUID(ini.GetLongValue("CLUTCH", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("CLUTCH", "AXLE", ""),
-            "Clutch", "CLUTCH");
+            "Clutch");
     Wheel.Clutch.Min = ini.GetLongValue("CLUTCH", "MIN", -1);
     Wheel.Clutch.Max = ini.GetLongValue("CLUTCH", "MAX", -1);
 
     // [HANDBRAKE_ANALOG]
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::Handbrake)] =
-        CarControls::SWheelInput<std::string>(
+        CarControls::SWheelInput<std::string>("HANDBRAKE_ANALOG",
             DeviceIndexToGUID(ini.GetLongValue("HANDBRAKE_ANALOG", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("HANDBRAKE_ANALOG", "AXLE", ""),
-            "Handbrake (Analog)", "HANDBRAKE_ANALOG");
+            "Handbrake (Analog)");
     Wheel.HandbrakeA.Min = ini.GetLongValue("HANDBRAKE_ANALOG", "MIN", -1);
     Wheel.HandbrakeA.Max = ini.GetLongValue("HANDBRAKE_ANALOG", "MAX", -1);
 
-    // [SHIFTER]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H1)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H2)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H3)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H4)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H5)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H6)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H7)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H8)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H9)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::H10)] =
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::HR)] =
-        DeviceIndexToGUID(ini.GetLongValue("SHIFTER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
+    // enums HR through H10 are explicitly defined as 0 through 10
+    // [HPATTERN_0]
+    scriptControl->WheelButton[0] =
+        parseWheelItem<int>(ini, "HPATTERN_0", -1, "H-pattern reverse");
 
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H1)] =
-        ini.GetLongValue("SHIFTER", "GEAR_1", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H2)] =
-        ini.GetLongValue("SHIFTER", "GEAR_2", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H3)] =
-        ini.GetLongValue("SHIFTER", "GEAR_3", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H4)] =
-        ini.GetLongValue("SHIFTER", "GEAR_4", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H5)] =
-        ini.GetLongValue("SHIFTER", "GEAR_5", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H6)] =
-        ini.GetLongValue("SHIFTER", "GEAR_6", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H7)] =
-        ini.GetLongValue("SHIFTER", "GEAR_7", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H8)] =
-        ini.GetLongValue("SHIFTER", "GEAR_8", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H9)] =
-        ini.GetLongValue("SHIFTER", "GEAR_9", -1);
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::H10)] =
-        ini.GetLongValue("SHIFTER", "GEAR_10", -1); 
-    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::HR)] =
-        ini.GetLongValue("SHIFTER", "GEAR_R", -1);
+    // [HPATTERN_<gear>]
+    for (uint8_t i = 1; i < 11; ++i) {
+        scriptControl->WheelButton[i] =
+            parseWheelItem<int>(ini, fmt::format("HPATTERN_{}", i).c_str(), -1, fmt::format("H-pattern {}", i).c_str());
+    }
 
     // [THROTTLE_BUTTON]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Throttle)] =
-        DeviceIndexToGUID(ini.GetLongValue("THROTTLE_BUTTON", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Throttle)] =
-        ini.GetLongValue("THROTTLE_BUTTON", "BUTTON", -1);
+        parseWheelItem<int>(ini, "THROTTLE_BUTTON", -1, "Throttle (Button)");
 
     // [BRAKE_BUTTON]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Brake)] =
-        DeviceIndexToGUID(ini.GetLongValue("BRAKE_BUTTON", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Brake)] =
-        ini.GetLongValue("BRAKE_BUTTON", "BUTTON", -1);
+        parseWheelItem<int>(ini, "BRAKE_BUTTON", -1, "Brake (Button)");
 
     // [CLUTCH_BUTTON]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Clutch)] =
-        DeviceIndexToGUID(ini.GetLongValue("CLUTCH_BUTTON", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Clutch)] =
-        ini.GetLongValue("CLUTCH_BUTTON", "BUTTON", -1);
+        parseWheelItem<int>(ini, "CLUTCH_BUTTON", -1, "Clutch (Button)");
 
     // [SHIFT_UP]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::ShiftUp)] =
-        DeviceIndexToGUID(ini.GetLongValue("SHIFT_UP", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ShiftUp)] =
-        ini.GetLongValue("SHIFT_UP", "BUTTON", -1);
+        parseWheelItem<int>(ini, "SHIFT_UP", -1);
 
     // [SHIFT_DOWN]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::ShiftDown)] =
-        DeviceIndexToGUID(ini.GetLongValue("SHIFT_DOWN", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ShiftDown)] =
-        ini.GetLongValue("SHIFT_DOWN", "BUTTON", -1);
+        parseWheelItem<int>(ini, "SHIFT_DOWN", -1);
 
     // [HANDBRAKE]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Handbrake)] =
-        DeviceIndexToGUID(ini.GetLongValue("HANDBRAKE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Handbrake)] =
-        ini.GetLongValue("HANDBRAKE", "BUTTON", -1);
+        parseWheelItem<int>(ini, "HANDBRAKE", -1);
 
     // [ENGINE]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Engine)] =
-        DeviceIndexToGUID(ini.GetLongValue("ENGINE", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Engine)] =
-        ini.GetLongValue("ENGINE", "BUTTON", -1);
+        parseWheelItem<int>(ini, "ENGINE", -1);
 
     // [LIGHTS]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Lights)] =
-        DeviceIndexToGUID(ini.GetLongValue("LIGHTS", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Lights)] =
-        ini.GetLongValue("LIGHTS", "BUTTON", -1);
+        parseWheelItem<int>(ini, "LIGHTS", -1);
 
     // [HORN]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Horn)] =
-        DeviceIndexToGUID(ini.GetLongValue("HORN", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Horn)] =
-        ini.GetLongValue("HORN", "BUTTON", -1);
+        parseWheelItem<int>(ini, "HORN", -1);
 
     // [LOOK_BACK]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::LookBack)] =
-        DeviceIndexToGUID(ini.GetLongValue("LOOK_BACK", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::LookBack)] =
-        ini.GetLongValue("LOOK_BACK", "BUTTON", -1);
-    
+        parseWheelItem<int>(ini, "LOOK_BACK", -1);
+
     // [LOOK_LEFT]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::LookLeft)] =
-        DeviceIndexToGUID(ini.GetLongValue("LOOK_LEFT", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::LookLeft)] =
-        ini.GetLongValue("LOOK_LEFT", "BUTTON", -1);
-    
+        parseWheelItem<int>(ini, "LOOK_LEFT", -1);
+
     // [LOOK_RIGHT]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::LookRight)] =
-        DeviceIndexToGUID(ini.GetLongValue("LOOK_RIGHT", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::LookRight)] =
-        ini.GetLongValue("LOOK_RIGHT", "BUTTON", -1);
+        parseWheelItem<int>(ini, "LOOK_RIGHT", -1);
 
     // [CHANGE_CAMERA]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::Camera)] =
-        DeviceIndexToGUID(ini.GetLongValue("CHANGE_CAMERA", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::Camera)] =
-        ini.GetLongValue("CHANGE_CAMERA", "BUTTON", -1);
+        parseWheelItem<int>(ini, "CHANGE_CAMERA", -1);
 
     // [RADIO_NEXT]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::RadioNext)] =
-        DeviceIndexToGUID(ini.GetLongValue("RADIO_NEXT", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::RadioNext)] =
-        ini.GetLongValue("RADIO_NEXT", "BUTTON", -1);
+        parseWheelItem<int>(ini, "RADIO_NEXT", -1);
 
     // [RADIO_PREVIOUS]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::RadioPrev)] =
-        DeviceIndexToGUID(ini.GetLongValue("RADIO_PREVIOUS", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::RadioPrev)] =
-        ini.GetLongValue("RADIO_PREVIOUS", "BUTTON", -1);
+        parseWheelItem<int>(ini, "RADIO_PREVIOUS", -1);
 
     // [INDICATOR_LEFT]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::IndicatorLeft)] =
-        DeviceIndexToGUID(ini.GetLongValue("INDICATOR_LEFT", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::IndicatorLeft)] =
-        ini.GetLongValue("INDICATOR_LEFT", "BUTTON", -1);
+        parseWheelItem<int>(ini, "INDICATOR_LEFT", -1);
 
     // [INDICATOR_RIGHT]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::IndicatorRight)] =
-        DeviceIndexToGUID(ini.GetLongValue("INDICATOR_RIGHT", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::IndicatorRight)] =
-        ini.GetLongValue("INDICATOR_RIGHT", "BUTTON", -1);
+        parseWheelItem<int>(ini, "INDICATOR_RIGHT", -1);
 
     // [INDICATOR_HAZARD]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::IndicatorHazard)] =
-        DeviceIndexToGUID(ini.GetLongValue("INDICATOR_HAZARD", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::IndicatorHazard)] =
-        ini.GetLongValue("INDICATOR_HAZARD", "BUTTON", -1);
+        parseWheelItem<int>(ini, "INDICATOR_HAZARD", -1);
 
     // [AUTO_P]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::APark)] =
-        DeviceIndexToGUID(ini.GetLongValue("AUTO_P", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::APark)] =
-        ini.GetLongValue("AUTO_P", "BUTTON", -1);
+        parseWheelItem<int>(ini, "AUTO_P", -1, "Automatic park");
 
     // [AUTO_R]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::AReverse)] =
-        DeviceIndexToGUID(ini.GetLongValue("AUTO_R", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::AReverse)] =
-        ini.GetLongValue("AUTO_R", "BUTTON", -1);
+        parseWheelItem<int>(ini, "AUTO_R", -1, "Automatic reverse");
 
     // [AUTO_N]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::ANeutral)] =
-        DeviceIndexToGUID(ini.GetLongValue("AUTO_N", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ANeutral)] =
-        ini.GetLongValue("AUTO_N", "BUTTON", -1);
+        parseWheelItem<int>(ini, "AUTO_N", -1, "Automatic neutral");
 
     // [AUTO_D]
-    scriptControl->WheelButtonGUIDs[static_cast<int>(CarControls::WheelControlType::ADrive)] =
-        DeviceIndexToGUID(ini.GetLongValue("AUTO_D", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs);
     scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ADrive)] =
-        ini.GetLongValue("AUTO_D", "BUTTON", -1);
+        parseWheelItem<int>(ini, "AUTO_D", -1, "Automatic drive");
+
+    // [CYCLE_ASSISTS]
+    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::CycleAssists)] =
+        parseWheelItem<int>(ini, "CYCLE_ASSISTS", -1);
+
+    // [TOGGLE_ABS]
+    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ToggleABS)] =
+        parseWheelItem<int>(ini, "TOGGLE_ABS", -1, "Toggle ABS");
+
+    // [TOGGLE_ESC]
+    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ToggleESC)] =
+        parseWheelItem<int>(ini, "TOGGLE_ESC", -1, "Toggle ESC");
+
+    // [TOGGLE_TCS]
+    scriptControl->WheelButton[static_cast<int>(CarControls::WheelControlType::ToggleTCS)] =
+        parseWheelItem<int>(ini, "TOGGLE_TCS", -1, "Toggle TCS");
 
     // [TO_KEYBOARD]
     scriptControl->WheelToKeyGUID = 
@@ -1296,6 +1232,37 @@ int ScriptSettings::GUIDToDeviceIndex(GUID guidToFind) {
         i++;
     }
     return -1;
+}
+
+template <typename T>
+CarControls::SWheelInput<T> ScriptSettings::parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name) {
+    std::string nameFmt;
+    if (name == nullptr) {
+        nameFmt = section;
+        std::transform(nameFmt.begin(), nameFmt.end(), nameFmt.begin(), [](char ch) {
+            return ch == '_' ? ' ' : ch;
+            });
+        nameFmt[0] = std::toupper(nameFmt[0]);
+        for (std::size_t i = 1; i < nameFmt.length(); ++i)
+            nameFmt[i] = std::tolower(nameFmt[i]);
+    }
+    else {
+        nameFmt = name;
+    }
+
+    if constexpr (std::is_same<T, int>::value) {
+        return CarControls::SWheelInput<T>(section,
+            DeviceIndexToGUID(ini.GetLongValue(section, "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetLongValue(section, "BUTTON", default), nameFmt.c_str());
+    }
+    else if constexpr (std::is_same<T, std::string>::value) {
+        return CarControls::SWheelInput<T>(section,
+            DeviceIndexToGUID(ini.GetLongValue(section, "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
+            ini.GetValue(section, "AXLE", default), nameFmt.c_str());
+    }
+    else {
+        static_assert(false, "Type must be string or int.");
+    }
 }
 
 #pragma warning(pop)

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -897,10 +897,10 @@ void ScriptSettings::parseSettingsWheel(CarControls *scriptControl) {
         parseWheelItem<std::string>(ini, "STEER", "", "Steering");
 
     scriptControl->WheelAxes[static_cast<int>(CarControls::WheelAxisType::ForceFeedback)] =
-        CarControls::SWheelInput<std::string>("FFB",
+        CarControls::SInput<std::string>("FFB",
             DeviceIndexToGUID(ini.GetLongValue("STEER", "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
             ini.GetValue("STEER", "FFB", ""),
-            "Force feedback");
+            "Force feedback", "Force feedback");
 
     Wheel.Steering.Min = ini.GetLongValue("STEER", "MIN", -1);
     Wheel.Steering.Max = ini.GetLongValue("STEER", "MAX", -1);
@@ -1225,37 +1225,37 @@ int ScriptSettings::GUIDToDeviceIndex(GUID guidToFind) {
 }
 
 template <typename T>
-CarControls::SWheelInput<T> ScriptSettings::parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name) {
+CarControls::SInput<T> ScriptSettings::parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name) {
     std::string nameFmt = formatInputName(section, name);
     if constexpr (std::is_same<T, int>::value) {
-        return CarControls::SWheelInput<T>(section,
+        return CarControls::SInput<T>(section,
             DeviceIndexToGUID(ini.GetLongValue(section, "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
-            ini.GetLongValue(section, "BUTTON", default), nameFmt.c_str());
+            ini.GetLongValue(section, "BUTTON", default), nameFmt.c_str(), "");
     }
     else if constexpr (std::is_same<T, std::string>::value) {
-        return CarControls::SWheelInput<T>(section,
+        return CarControls::SInput<T>(section,
             DeviceIndexToGUID(ini.GetLongValue(section, "DEVICE", -1), Wheel.InputDevices.RegisteredGUIDs),
-            ini.GetValue(section, "AXLE", default.c_str()), nameFmt.c_str());
+            ini.GetValue(section, "AXLE", default.c_str()), nameFmt.c_str(), "");
     }
     else {
         static_assert(false, "Type must be string or int.");
     }
 }
 
-CarControls::SKeyboardInput ScriptSettings::parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name) {
+CarControls::SInput<int> ScriptSettings::parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name) {
     std::string nameFmt = formatInputName(key, name);
-    return CarControls::SKeyboardInput(key, str2key(ini.GetValue("KEYBOARD", key, default)), nameFmt);
+    return CarControls::SInput<int>(key, {}, str2key(ini.GetValue("KEYBOARD", key, default)), nameFmt, "");
 }
 
 template <typename T>
-CarControls::SControllerInput<T> ScriptSettings::parseControllerItem(CSimpleIniA& ini, const char* key, T default, const char* name, const char* description) {
+CarControls::SInput<T> ScriptSettings::parseControllerItem(CSimpleIniA& ini, const char* key, T default, const char* name, const char* description) {
     if constexpr (std::is_same<T, eControl>::value) {
-        return CarControls::SControllerInput<T>(key,
+        return CarControls::SInput<T>(key, {},
             static_cast<T>(ini.GetLongValue("CONTROLLER_NATIVE", key, static_cast<int>(default))),
             name, description);
     }
     else if constexpr (std::is_same<T, std::string>::value) {
-        return CarControls::SControllerInput<T>(key,
+        return CarControls::SInput<T>(key, {},
             ini.GetValue("CONTROLLER", key, default.c_str()),
             name, description);
     }

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -435,7 +435,6 @@ public:
     int GUIDToDeviceIndex(GUID guid);
 
     void SteeringSaveAxis(const std::string &confTag, ptrdiff_t index, const std::string &axis, int minVal, int maxVal);
-    void SteeringSaveFFBAxis(const std::string &confTag, ptrdiff_t index, const std::string &axis);
     void SteeringSaveButton(const std::string &confTag, ptrdiff_t index, int button);
     void SteeringSaveHShifter(const std::string &confTag, ptrdiff_t index, const std::vector<int>& button);
     void KeyboardSaveKey(const std::string &confTag, const std::string &key);

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -453,7 +453,11 @@ private:
 
     template<typename T>
     CarControls::SWheelInput<T> parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name = nullptr);
+
     CarControls::SKeyboardInput parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name = nullptr);
+
+    template<typename T>
+    CarControls::SControllerInput<T> parseControllerItem(CSimpleIniA& ini, const char* key, T default, const char* name, const char* description);
 
     int nDevices = 0;
     std::string settingsGeneralFile;

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -452,12 +452,12 @@ private:
     GUID DeviceIndexToGUID(int device, std::vector<GUID> guids);
 
     template<typename T>
-    CarControls::SWheelInput<T> parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name = nullptr);
+    CarControls::SInput<T> parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name = nullptr);
 
-    CarControls::SKeyboardInput parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name = nullptr);
+    CarControls::SInput<int> parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name = nullptr);
 
     template<typename T>
-    CarControls::SControllerInput<T> parseControllerItem(CSimpleIniA& ini, const char* key, T default, const char* name, const char* description);
+    CarControls::SInput<T> parseControllerItem(CSimpleIniA& ini, const char* key, T default, const char* name, const char* description);
 
     int nDevices = 0;
     std::string settingsGeneralFile;

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -1,13 +1,13 @@
 #pragma once
-#include <Windows.h>
 
-#include <vector>
+#include "Input/CarControls.hpp"
 #include "Util/Logger.hpp"
-#include "simpleini/SimpleIni.h"
+
+#include <simpleini/SimpleIni.h>
+#include <vector>
+#include <string>
 
 class VehicleConfig;
-class Logger;
-class CarControls;
 
 enum class EShiftMode : int {
     Sequential = 0,
@@ -451,6 +451,9 @@ private:
 
     // Just looks up which GUID corresponds with what number and returns the GUID.
     GUID DeviceIndexToGUID(int device, std::vector<GUID> guids);
+
+    template<typename T>
+    CarControls::SWheelInput<T> parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name = nullptr);
 
     int nDevices = 0;
     std::string settingsGeneralFile;

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -453,6 +453,7 @@ private:
 
     template<typename T>
     CarControls::SWheelInput<T> parseWheelItem(CSimpleIniA& ini, const char* section, T default, const char* name = nullptr);
+    CarControls::SKeyboardInput parseKeyboardItem(CSimpleIniA& ini, const char* key, const char* default, const char* name = nullptr);
 
     int nDevices = 0;
     std::string settingsGeneralFile;

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -495,10 +495,10 @@ void update_manual_transmission() {
         g_settings.SaveGeneral();
     }
 
-    if (g_controls.ButtonJustPressed(CarControls::KeyboardControlType::SwitchAssist) || 
-        g_controls.ButtonJustPressed(CarControls::WheelControlType::SwitchAssist) ||
-        g_controls.ButtonHeld(CarControls::ControllerControlType::SwitchAssist) ||
-        g_controls.PrevInput == CarControls::Controller && g_controls.ButtonHeld(CarControls::LegacyControlType::SwitchAssist)) {
+    if (g_controls.ButtonJustPressed(CarControls::KeyboardControlType::CycleAssists) || 
+        g_controls.ButtonJustPressed(CarControls::WheelControlType::CycleAssists) ||
+        g_controls.ButtonHeld(CarControls::ControllerControlType::CycleAssists) ||
+        g_controls.PrevInput == CarControls::Controller && g_controls.ButtonHeld(CarControls::LegacyControlType::CycleAssists)) {
 
         uint8_t currMode = 0;
         // 3: ABS + ESC + TCS

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -1116,7 +1116,7 @@ bool subAutoShiftSelect() {
         return true;
     }
     // Unassigned neutral -> pop into neutral when any gear is released
-    if (g_controls.WheelButton[static_cast<int>(CarControls::WheelControlType::ANeutral)] == -1) {
+    if (g_controls.WheelButton[static_cast<int>(CarControls::WheelControlType::ANeutral)].Control == -1) {
         if (g_controls.ButtonReleased(CarControls::WheelControlType::APark) ||
             g_controls.ButtonReleased(CarControls::WheelControlType::AReverse) ||
             g_controls.ButtonReleased(CarControls::WheelControlType::ADrive)) {

--- a/WheelSetup/WheelSetup.cpp
+++ b/WheelSetup/WheelSetup.cpp
@@ -148,7 +148,10 @@ void init() {
  */
 void playWheelEffects(float effSteer) {
 	if (g_settings.Wheel.Options.LogiLEDs) {
-		controls.GetWheel().PlayLedsDInput(controls.WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Steer)], controls.ThrottleVal, 0.5f, 0.95f);
+		controls.GetWheel().PlayLedsDInput(
+			controls.WheelAxes[static_cast<int>(CarControls::WheelAxisType::Steer)].Guid,
+			controls.ThrottleVal,
+			0.5f, 0.95f);
 	}
 
 	auto totalForce = static_cast<int>(controls.ThrottleVal * 20000.0f * 2.0f * (controls.SteerVal - 0.5f));
@@ -206,9 +209,6 @@ void saveAxis(const std::string& confTag, GUID devGUID, const std::string& axis,
 	std::string devName = StrUtil::utf8_encode(wDevName);
 	auto index = g_settings.SteeringAppendDevice(devGUID, devName);
 	g_settings.SteeringSaveAxis(confTag, index, axis, min, max);
-	if (confTag == "STEER") {
-		g_settings.SteeringSaveFFBAxis(confTag, index, axis);
-	}
 	g_settings.Read(&controls);
 }
 
@@ -890,7 +890,7 @@ int main() {
 		if (controls.ButtonIn(CarControls::WheelControlType::Toggle)) std::cout << "ToggleMod ";
 		if (controls.ButtonIn(CarControls::WheelControlType::ToggleH)) std::cout << "ChangeShiftMode ";
 
-		if (controls.GetWheel().IsConnected(controls.WheelAxesGUIDs[static_cast<int>(CarControls::WheelAxisType::Steer)]))
+		if (controls.GetWheel().IsConnected(controls.WheelAxes[static_cast<int>(CarControls::WheelAxisType::ForceFeedback)].Guid))
 			playWheelEffects(effSteer);
 		
 		setCursorPosition(0, csbi.srWindow.Bottom - 9);

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 4.7.2
+## 4.8.0
 
 Lots of small fixes and improvements! The settings files are generally
-compatible, but a `SHIFT_ASSISTS` typo fix now ignores the old
-wrongly spelled `SHIFT_ASSIST` section.
+compatible, aside from the following:
+
+* `SHIFT_ASSISTS` typo fix: now ignores the old wrongly spelled `SHIFT_ASSIST` section
+* H-Pattern shifter assignment changed, now each gear has its own entry
 
 * Engine and transmission
   * Add alternate automatic transmission mode, by [Nyconing](https://github.com/Nyconing)


### PR DESCRIPTION
🧹 

Got rid of like 11 loosely synced tables describing control <-> menu name <-> settings name <-> other stuff relations, jammed them all in a convenient generic struct. Adding more buttons now means not going through years of spaghetti code any more 🥳 

Notes:

* H-pattern shifter assignment now has "button" entries for gear individually
* Everything else should stay untouched (on the user side)
* Slight menu improvements for controller and keyboard.