### PR TITLE
Feature/stalling clutch improvements

### DIFF
--- a/Gears/Gears.vcxproj
+++ b/Gears/Gears.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="SteeringAnim.cpp" />
     <ClCompile Include="UDPTelemetry\UDPTelemetry.cpp" />
     <ClCompile Include="UpdateChecker.cpp" />
+    <ClCompile Include="Util\Color.cpp" />
     <ClCompile Include="Util\Files.cpp" />
     <ClCompile Include="Util\FileVersion.cpp" />
     <ClCompile Include="Util\GameSound.cpp" />

--- a/Gears/Gears.vcxproj.filters
+++ b/Gears/Gears.vcxproj.filters
@@ -213,6 +213,9 @@
     </ClCompile>
     <ClCompile Include="AtcuLogic.cpp" />
     <ClCompile Include="AtcuGearbox.cpp" />
+    <ClCompile Include="Util\Color.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="script.h" />

--- a/Gears/ScriptHUD.cpp
+++ b/Gears/ScriptHUD.cpp
@@ -293,11 +293,30 @@ void drawRPMIndicator() {
     // Stall indicator
     if (Math::Near(g_vehData.mRPM, 0.2f, 0.01f) && g_gearStates.StallProgress > 0.0f) {
         rpm = map(g_gearStates.StallProgress, 0.0f, 1.0f, 0.2f, 0.0f);
-        rpmcolor = {
-            255,
-            std::clamp((int)map(rpm, 0.0f, 0.2f, 255.0f, 0.0f), 0, 255),
-            std::clamp((int)map(rpm, 0.0f, 0.1f, 255.0f, 0.0f), 0, 255),
-            255
+
+        auto hsvColor = Util::RGB2HSV(Util::ColorF {
+            static_cast<float>(rpmcolor.R) / 255.0f,
+            static_cast<float>(rpmcolor.G) / 255.0f,
+            static_cast<float>(rpmcolor.B) / 255.0f,
+            1.0f, // alpha is ignored anyway
+        });
+
+        // hue: transition orange to red
+        hsvColor.R = map(rpm, 0.0f, 0.2f, 0.0f, 30.0f);        
+
+        // sat: transition whatever to full saturation
+        hsvColor.G = std::clamp(map(rpm, 0.1f, 0.2f, 1.0f, hsvColor.G), 0.0f, 1.0f);
+
+        // val: transition whatever to max saturated brightness
+        hsvColor.B = std::clamp(map(rpm, 0.1f, 0.2f, 1.0f, hsvColor.B), 0.0f, 1.0f);
+
+        auto rgbF = Util::HSV2RGB(hsvColor);
+
+        rpmcolor = Util::ColorI {
+            static_cast<int>(rgbF.R * 255.0f),
+            static_cast<int>(rgbF.G * 255.0f),
+            static_cast<int>(rgbF.B * 255.0f),
+            rpmcolor.A,
         };
     }
 

--- a/Gears/ScriptHUD.cpp
+++ b/Gears/ScriptHUD.cpp
@@ -28,6 +28,7 @@ extern VehicleGearboxStates g_gearStates;
 extern VehicleExtensions g_ext;
 extern Vehicle g_playerVehicle;
 extern VehicleData g_vehData;
+extern VehiclePeripherals g_peripherals;
 
 ///////////////////////////////////////////////////////////////////////////////
 //                           Display elements
@@ -59,6 +60,12 @@ void updateDashLights() {
         abs |= g_vehData.mWheelsAbs[i];
         tcs |= g_vehData.mWheelsTcs[i];
         esp |= g_vehData.mWheelsEspO[i] || g_vehData.mWheelsEspU[i];
+    }
+
+    if (g_peripherals.IgnitionState == IgnitionState::Stall) {
+        abs = true;
+        tcs = true;
+        esp = true;
     }
 
     if (abs)

--- a/Gears/ScriptHUD.cpp
+++ b/Gears/ScriptHUD.cpp
@@ -287,6 +287,20 @@ void drawRPMIndicator() {
         };
         rpmcolor = rpmlimiter;
     }
+
+    float rpm = g_vehData.mRPM;
+
+    // Stall indicator
+    if (Math::Near(g_vehData.mRPM, 0.2f, 0.01f) && g_gearStates.StallProgress > 0.0f) {
+        rpm = map(g_gearStates.StallProgress, 0.0f, 1.0f, 0.2f, 0.0f);
+        rpmcolor = {
+            255,
+            std::clamp((int)map(rpm, 0.0f, 0.2f, 255.0f, 0.0f), 0, 255),
+            std::clamp((int)map(rpm, 0.0f, 0.1f, 255.0f, 0.0f), 0, 255),
+            255
+        };
+    }
+
     drawRPMIndicator(
         g_settings.HUD.RPMBar.XPos,
         g_settings.HUD.RPMBar.YPos,
@@ -294,7 +308,7 @@ void drawRPMIndicator() {
         g_settings.HUD.RPMBar.YSz,
         rpmcolor,
         background,
-        g_vehData.mRPM
+        rpm
     );
 }
 

--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -393,6 +393,13 @@ void update_finetuneoptionsmenu() {
         { "RPM where engine braking starts being effective." });
     g_menu.FloatOption("Engine braking power", g_settings.MTParams.EngBrakePower, 0.0f, 5.0f, 0.05f,
         { "Decrease this value if your wheels lock up when engine braking." });
+
+    // Clutch creep params
+    g_menu.FloatOption("Clutch creep idle RPM", g_settings.MTParams.CreepIdleRPM, 0.0f, 0.5f, 0.01f,
+        { "RPM at which the engine should be idling and the car wants to move by itself.",
+          "Engines in GTA idle at 0.2, but this is rather high."});
+    g_menu.FloatOption("Clutch creep throttle", g_settings.MTParams.CreepIdleThrottle, 0.0f, 1.0f, 0.01f,
+        { "How much throttle is given when the car speed drops below the idle RPM." });
 }
 
 void update_shiftingoptionsmenu() {

--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -378,12 +378,15 @@ void update_finetuneoptionsmenu() {
     g_menu.Subtitle("");
 
     g_menu.FloatOption("Clutch bite threshold", g_settings.MTParams.ClutchThreshold, 0.0f, 1.0f, 0.05f,
-        { "How far the clutch has to be lifted to start biting. This value should be lower than \"Stalling threshold\"." });
-    g_menu.FloatOption("Stalling threshold", g_settings.MTParams.StallingThreshold, 0.0f, 1.0f, 0.05f,
-        { "How far the clutch has to be lifted to start stalling. This value should be higher than \"Clutch bite point\"." });
+        { "How far the clutch has to be lifted to start biting." });
     g_menu.FloatOption("Stalling RPM", g_settings.MTParams.StallingRPM, 0.0f, 0.2f, 0.01f,
-        { "Consider stalling when the expected RPM drops below this number.",
-          "The range is 0.0 to 0.2. The engine idles at 0.2, so 0.1 is a decent value." });
+        { "Consider stalling when the expected RPM drops below this value.",
+          "The range is 0.0 to 0.2. The engine idles at 0.2 in GTA.",
+          "Expected RPM is based on car speed and current gear ratio."});
+    g_menu.FloatOption("Stalling rate", g_settings.MTParams.StallingRate, 0.0f, 10.0f, 0.05f,
+        { "How quick the engine should stall. Higher values make it stall faster." });
+    g_menu.FloatOption("Stalling slip", g_settings.MTParams.StallingSlip, 0.0f, 1.0f, 0.05f,
+        { "How much the clutch may slip before the stalling rate picks up." });
 
     g_menu.FloatOption("RPM damage", g_settings.MTParams.RPMDamage, 0.0f, 10.0f, 0.05f,
         { "Damage from redlining too long." });

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -64,6 +64,8 @@ void ScriptSettings::SetVehicleConfig(VehicleConfig* cfg) {
     localSettings.MTParams.StallingRPM        = activeConfig->MTParams.StallingRPM      ;
     localSettings.MTParams.RPMDamage          = activeConfig->MTParams.RPMDamage        ;
     localSettings.MTParams.MisshiftDamage     = activeConfig->MTParams.MisshiftDamage   ;
+    localSettings.MTParams.CreepIdleThrottle  = activeConfig->MTParams.CreepIdleThrottle;
+    localSettings.MTParams.CreepIdleRPM       = activeConfig->MTParams.CreepIdleRPM     ;
 
     localSettings.DriveAssists.ABS.Enable       = activeConfig->DriveAssists.ABS.Enable      ;
     localSettings.DriveAssists.ABS.Filter       = activeConfig->DriveAssists.ABS.Filter      ;
@@ -231,6 +233,8 @@ void ScriptSettings::SaveGeneral() const {
     ini.SetDoubleValue("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
     ini.SetDoubleValue("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);
     ini.SetDoubleValue("MT_PARAMS", "EngBrakeThreshold", MTParams.EngBrakeThreshold);
+    ini.SetDoubleValue("MT_PARAMS", "CreepIdleThrottle", MTParams.CreepIdleThrottle);
+    ini.SetDoubleValue("MT_PARAMS", "CreepIdleRPM", MTParams.CreepIdleRPM);
 
     // [GAMEPLAY_ASSISTS]
     ini.SetBoolValue("GAMEPLAY_ASSISTS", "SimpleBike", GameAssists.SimpleBike);
@@ -532,6 +536,8 @@ void ScriptSettings::parseSettingsGeneral() {
     MTParams.MisshiftDamage =       ini.GetDoubleValue("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
     MTParams.EngBrakePower =        ini.GetDoubleValue("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);
     MTParams.EngBrakeThreshold =    ini.GetDoubleValue("MT_PARAMS", "EngBrakeThreshold", MTParams.EngBrakeThreshold);
+    MTParams.CreepIdleThrottle =    ini.GetDoubleValue("MT_PARAMS", "CreepIdleThrottle", MTParams.CreepIdleThrottle);
+    MTParams.CreepIdleRPM      =    ini.GetDoubleValue("MT_PARAMS", "CreepIdleRPM"     , MTParams.CreepIdleRPM     );
 
     GameAssists.DefaultNeutral =    ini.GetBoolValue("GAMEPLAY_ASSISTS", "DefaultNeutral", GameAssists.DefaultNeutral);
     GameAssists.SimpleBike =        ini.GetBoolValue("GAMEPLAY_ASSISTS", "SimpleBike", GameAssists.SimpleBike);

--- a/Gears/ScriptSettings.cpp
+++ b/Gears/ScriptSettings.cpp
@@ -60,8 +60,9 @@ void ScriptSettings::SetVehicleConfig(VehicleConfig* cfg) {
     localSettings.MTParams.EngBrakePower      = activeConfig->MTParams.EngBrakePower    ;
     localSettings.MTParams.EngBrakeThreshold  = activeConfig->MTParams.EngBrakeThreshold;
     localSettings.MTParams.ClutchThreshold    = activeConfig->MTParams.ClutchThreshold  ;
-    localSettings.MTParams.StallingThreshold  = activeConfig->MTParams.StallingThreshold;
     localSettings.MTParams.StallingRPM        = activeConfig->MTParams.StallingRPM      ;
+    localSettings.MTParams.StallingRate       = activeConfig->MTParams.StallingRate     ;
+    localSettings.MTParams.StallingSlip       = activeConfig->MTParams.StallingSlip     ;
     localSettings.MTParams.RPMDamage          = activeConfig->MTParams.RPMDamage        ;
     localSettings.MTParams.MisshiftDamage     = activeConfig->MTParams.MisshiftDamage   ;
     localSettings.MTParams.CreepIdleThrottle  = activeConfig->MTParams.CreepIdleThrottle;
@@ -227,8 +228,9 @@ void ScriptSettings::SaveGeneral() const {
 
     // [MT_PARAMS]
     ini.SetDoubleValue("MT_PARAMS", "ClutchCatchpoint", MTParams.ClutchThreshold);
-    ini.SetDoubleValue("MT_PARAMS", "StallingThreshold", MTParams.StallingThreshold);
     ini.SetDoubleValue("MT_PARAMS", "StallingRPM", MTParams.StallingRPM);
+    ini.SetDoubleValue("MT_PARAMS", "StallingRate", MTParams.StallingRate);
+    ini.SetDoubleValue("MT_PARAMS", "StallingSlip", MTParams.StallingSlip);
     ini.SetDoubleValue("MT_PARAMS", "RPMDamage", MTParams.RPMDamage);
     ini.SetDoubleValue("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
     ini.SetDoubleValue("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);
@@ -530,8 +532,9 @@ void ScriptSettings::parseSettingsGeneral() {
     MTOptions.HardLimiter = ini.GetBoolValue("MT_OPTIONS", "HardLimiter", MTOptions.HardLimiter);
 
     MTParams.ClutchThreshold =      ini.GetDoubleValue("MT_PARAMS", "ClutchCatchpoint", MTParams.ClutchThreshold);
-    MTParams.StallingThreshold =    ini.GetDoubleValue("MT_PARAMS", "StallingThreshold", MTParams.StallingThreshold);
     MTParams.StallingRPM =          ini.GetDoubleValue("MT_PARAMS", "StallingRPM", MTParams.StallingRPM);
+    MTParams.StallingRate =         ini.GetDoubleValue("MT_PARAMS", "StallingRate", MTParams.StallingRate);
+    MTParams.StallingSlip =         ini.GetDoubleValue("MT_PARAMS", "StallingSlip", MTParams.StallingSlip);
     MTParams.RPMDamage =            ini.GetDoubleValue("MT_PARAMS", "RPMDamage", MTParams.RPMDamage);
     MTParams.MisshiftDamage =       ini.GetDoubleValue("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
     MTParams.EngBrakePower =        ini.GetDoubleValue("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -77,6 +77,8 @@ public:
         float StallingRPM = 0.1f;
         float RPMDamage = 0.1f;
         float MisshiftDamage = 5.0f;
+        float CreepIdleThrottle = 0.1f;
+        float CreepIdleRPM = 0.1f;
     } MTParams;
 
     // [GAMEPLAY_ASSISTS]

--- a/Gears/ScriptSettings.hpp
+++ b/Gears/ScriptSettings.hpp
@@ -72,9 +72,9 @@ public:
         float EngBrakeThreshold = 0.75f;
         // Clutch _lift_ distance
         float ClutchThreshold = 0.15f;
-        // Clutch _lift_ distance
-        float StallingThreshold = 0.35f;
-        float StallingRPM = 0.1f;
+        float StallingRPM = 0.09f;
+        float StallingRate = 3.75f;
+        float StallingSlip = 0.40f;
         float RPMDamage = 0.1f;
         float MisshiftDamage = 5.0f;
         float CreepIdleThrottle = 0.1f;

--- a/Gears/Util/Color.cpp
+++ b/Gears/Util/Color.cpp
@@ -1,0 +1,99 @@
+#include "Color.h"
+#include <algorithm>
+#include <cmath>
+
+Util::ColorF Util::RGB2HSV(ColorF rgb) {
+    ColorF hsv{};
+    auto fR = rgb.R;
+    auto fG = rgb.G;
+    auto fB = rgb.B;
+
+    auto fCMax = std::max(std::max(fR, fG), fB);
+    auto fCMin = std::min(std::min(fR, fG), fB);
+    auto fDelta = fCMax - fCMin;
+
+    if (fDelta > 0.0f) {
+        if (fCMax == fR) {
+            hsv.R = 60.0f * (std::fmod(((fG - fB) / fDelta), 6.0f));
+        }
+        else if (fCMax == fG) {
+            hsv.R = 60.0f * (((fB - fR) / fDelta) + 2.0f);
+        }
+        else if (fCMax == fB) {
+            hsv.R = 60.0f * (((fR - fG) / fDelta) + 4.0f);
+        }
+
+        if (fCMax > 0.0f) {
+            hsv.G = fDelta / fCMax;
+        }
+        else {
+            hsv.G = 0.0f;
+        }
+
+        hsv.B = fCMax;
+    }
+    else {
+        hsv.R = 0.0f;
+        hsv.G = 0.0f;
+        hsv.B = fCMax;
+    }
+
+    if (hsv.R < 0.0) {
+        hsv.R = 360.0f + hsv.R;
+    }
+    return hsv;
+}
+
+Util::ColorF Util::HSV2RGB(ColorF hsv) {
+    ColorF rgb{};
+    auto fH = hsv.R;
+    auto fS = hsv.G;
+    auto fV = hsv.B;
+
+    auto fC = fV * fS; // Chroma
+    auto fHPrime = std::fmod(fH / 60.0f, 6.0f);
+    auto fX = fC * (1.0f - std::abs(fmod(fHPrime, 2.0f) - 1.0f));
+    auto fM = fV - fC;
+
+    if (0.0f <= fHPrime && fHPrime < 1.0f) {
+        rgb.R = fC;
+        rgb.G = fX;
+        rgb.B = 0.0f;
+    }
+    else if (1.0f <= fHPrime && fHPrime < 2.0f) {
+        rgb.R = fX;
+        rgb.G = fC;
+        rgb.B = 0.0f;
+    }
+    else if (2.0f <= fHPrime && fHPrime < 3.0f) {
+        rgb.R = 0.0f;
+        rgb.G = fC;
+        rgb.B = fX;
+    }
+    else if (3.0f <= fHPrime && fHPrime < 4.0f) {
+        rgb.R = 0.0f;
+        rgb.G = fX;
+        rgb.B = fC;
+    }
+    else if (4.0f <= fHPrime && fHPrime < 5.0f) {
+        rgb.R = fX;
+        rgb.G = 0.0f;
+        rgb.B = fC;
+    }
+    else if (5.0 <= fHPrime && fHPrime < 6.0) {
+        rgb.R = fC;
+        rgb.G = 0.0;
+        rgb.B = fX;
+    }
+    else {
+        rgb.R = 0.0f;
+        rgb.G = 0.0f;
+        rgb.B = 0.0f;
+    }
+
+    rgb.R += fM;
+    rgb.G += fM;
+    rgb.B += fM;
+
+    return rgb;
+}

--- a/Gears/Util/Color.h
+++ b/Gears/Util/Color.h
@@ -33,4 +33,16 @@ namespace Util {
 
         const ColorI TransparentGray = { 75, 75, 75, 75 };
     }
+
+    // Returns HSV in RGB Color struct
+    // R -> H
+    // G -> S
+    // B -> V
+    ColorF RGB2HSV(ColorF rgb);
+
+    // Takes HSV in RGB Color struct
+    // R -> H
+    // G -> S
+    // B -> V
+    ColorF HSV2RGB(ColorF hsv);
 }

--- a/Gears/VehicleConfig.cpp
+++ b/Gears/VehicleConfig.cpp
@@ -44,6 +44,8 @@ void VehicleConfig::loadSettings(const ScriptSettings& gSettings, const std::str
     MTParams.MisshiftDamage = ini.GetDoubleValue("MT_PARAMS", "MisshiftDamage", gSettings.MTParams.MisshiftDamage);
     MTParams.EngBrakePower = ini.GetDoubleValue("MT_PARAMS", "EngBrakePower", gSettings.MTParams.EngBrakePower);
     MTParams.EngBrakeThreshold = ini.GetDoubleValue("MT_PARAMS", "EngBrakeThreshold", gSettings.MTParams.EngBrakeThreshold);
+    MTParams.CreepIdleThrottle = ini.GetDoubleValue("MT_PARAMS", "CreepIdleThrottle", gSettings.MTParams.CreepIdleThrottle);
+    MTParams.CreepIdleRPM = ini.GetDoubleValue("MT_PARAMS", "CreepIdleRPM", gSettings.MTParams.CreepIdleRPM);
 
     // [DRIVING_ASSISTS]
     DriveAssists.ABS.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ABS", DriveAssists.ABS.Enable);

--- a/Gears/VehicleConfig.cpp
+++ b/Gears/VehicleConfig.cpp
@@ -38,8 +38,9 @@ void VehicleConfig::loadSettings(const ScriptSettings& gSettings, const std::str
 
     // [MT_PARAMS]
     MTParams.ClutchThreshold = ini.GetDoubleValue("MT_PARAMS", "ClutchCatchpoint", gSettings.MTParams.ClutchThreshold);
-    MTParams.StallingThreshold = ini.GetDoubleValue("MT_PARAMS", "StallingThreshold", gSettings.MTParams.StallingThreshold);
     MTParams.StallingRPM = ini.GetDoubleValue("MT_PARAMS", "StallingRPM", gSettings.MTParams.StallingRPM);
+    MTParams.StallingRate = ini.GetDoubleValue("MT_PARAMS", "StallingRate", gSettings.MTParams.StallingRate);
+    MTParams.StallingSlip = ini.GetDoubleValue("MT_PARAMS", "StallingSlip", gSettings.MTParams.StallingSlip);
     MTParams.RPMDamage = ini.GetDoubleValue("MT_PARAMS", "RPMDamage", gSettings.MTParams.RPMDamage);
     MTParams.MisshiftDamage = ini.GetDoubleValue("MT_PARAMS", "MisshiftDamage", gSettings.MTParams.MisshiftDamage);
     MTParams.EngBrakePower = ini.GetDoubleValue("MT_PARAMS", "EngBrakePower", gSettings.MTParams.EngBrakePower);

--- a/Gears/VehicleConfig.cpp
+++ b/Gears/VehicleConfig.cpp
@@ -49,20 +49,20 @@ void VehicleConfig::loadSettings(const ScriptSettings& gSettings, const std::str
     MTParams.CreepIdleRPM = ini.GetDoubleValue("MT_PARAMS", "CreepIdleRPM", gSettings.MTParams.CreepIdleRPM);
 
     // [DRIVING_ASSISTS]
-    DriveAssists.ABS.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ABS", DriveAssists.ABS.Enable);
-    DriveAssists.ABS.Filter = ini.GetBoolValue("DRIVING_ASSISTS", "ABSFilter", DriveAssists.ABS.Filter);
-    DriveAssists.TCS.Enable = ini.GetLongValue("DRIVING_ASSISTS", "TCS", DriveAssists.TCS.Enable);
-    DriveAssists.TCS.Mode = ini.GetLongValue("DRIVING_ASSISTS", "TCSMode", DriveAssists.TCS.Mode);
-    DriveAssists.TCS.SlipMax = ini.GetDoubleValue("DRIVING_ASSISTS", "TCSSlipMax", DriveAssists.TCS.SlipMax);
-    DriveAssists.ESP.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ESP", DriveAssists.ESP.Enable);
-    DriveAssists.ESP.OverMin = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMin", DriveAssists.ESP.OverMin);
-    DriveAssists.ESP.OverMax = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMax", DriveAssists.ESP.OverMax);
-    DriveAssists.ESP.OverMinComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMinComp", DriveAssists.ESP.OverMinComp);
-    DriveAssists.ESP.OverMaxComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMaxComp", DriveAssists.ESP.OverMaxComp);
-    DriveAssists.ESP.UnderMin = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMin", DriveAssists.ESP.UnderMin);
-    DriveAssists.ESP.UnderMax = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMax", DriveAssists.ESP.UnderMax);
-    DriveAssists.ESP.UnderMinComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMinComp", DriveAssists.ESP.UnderMinComp);
-    DriveAssists.ESP.UnderMaxComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMaxComp", DriveAssists.ESP.UnderMaxComp);
+    DriveAssists.ABS.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ABS", gSettings.DriveAssists.ABS.Enable);
+    DriveAssists.ABS.Filter = ini.GetBoolValue("DRIVING_ASSISTS", "ABSFilter", gSettings.DriveAssists.ABS.Filter);
+    DriveAssists.TCS.Enable = ini.GetLongValue("DRIVING_ASSISTS", "TCS", gSettings.DriveAssists.TCS.Enable);
+    DriveAssists.TCS.Mode = ini.GetLongValue("DRIVING_ASSISTS", "TCSMode", gSettings.DriveAssists.TCS.Mode);
+    DriveAssists.TCS.SlipMax = ini.GetDoubleValue("DRIVING_ASSISTS", "TCSSlipMax", gSettings.DriveAssists.TCS.SlipMax);
+    DriveAssists.ESP.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ESP", gSettings.DriveAssists.ESP.Enable);
+    DriveAssists.ESP.OverMin = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMin", gSettings.DriveAssists.ESP.OverMin);
+    DriveAssists.ESP.OverMax = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMax", gSettings.DriveAssists.ESP.OverMax);
+    DriveAssists.ESP.OverMinComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMinComp", gSettings.DriveAssists.ESP.OverMinComp);
+    DriveAssists.ESP.OverMaxComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMaxComp", gSettings.DriveAssists.ESP.OverMaxComp);
+    DriveAssists.ESP.UnderMin = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMin", gSettings.DriveAssists.ESP.UnderMin);
+    DriveAssists.ESP.UnderMax = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMax", gSettings.DriveAssists.ESP.UnderMax);
+    DriveAssists.ESP.UnderMinComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMinComp", gSettings.DriveAssists.ESP.UnderMinComp);
+    DriveAssists.ESP.UnderMaxComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMaxComp", gSettings.DriveAssists.ESP.UnderMaxComp);
 
     // [SHIFT_OPTIONS]
     ShiftOptions.UpshiftCut = ini.GetBoolValue("SHIFT_OPTIONS", "UpshiftCut", gSettings.ShiftOptions.UpshiftCut);
@@ -101,68 +101,68 @@ void VehicleConfig::loadSettings(const ScriptSettings& gSettings, const std::str
     Wheel.Steering.Gamma = ini.GetDoubleValue("STEER", "Gamma", gSettings.Wheel.Steering.Gamma);
 
     // [HUD]
-    HUD.Enable = ini.GetBoolValue("HUD", "EnableHUD", HUD.Enable);
-    HUD.Font = ini.GetLongValue("HUD", "HUDFont", HUD.Font);
-    HUD.Outline = ini.GetBoolValue("HUD", "Outline", HUD.Outline);
+    HUD.Enable = ini.GetBoolValue("HUD", "EnableHUD", gSettings.HUD.Enable);
+    HUD.Font = ini.GetLongValue("HUD", "HUDFont", gSettings.HUD.Font);
+    HUD.Outline = ini.GetBoolValue("HUD", "Outline", gSettings.HUD.Outline);
 
-    HUD.Gear.Enable = ini.GetBoolValue("HUD", "GearIndicator", HUD.Gear.Enable);
-    HUD.Gear.XPos = ini.GetDoubleValue("HUD", "GearXpos", HUD.Gear.XPos);
-    HUD.Gear.YPos = ini.GetDoubleValue("HUD", "GearYpos", HUD.Gear.YPos);
-    HUD.Gear.Size = ini.GetDoubleValue("HUD", "GearSize", HUD.Gear.Size);
-    HUD.Gear.TopColorR = ini.GetLongValue("HUD", "GearTopColorR", HUD.Gear.TopColorR);
-    HUD.Gear.TopColorG = ini.GetLongValue("HUD", "GearTopColorG", HUD.Gear.TopColorG);
-    HUD.Gear.TopColorB = ini.GetLongValue("HUD", "GearTopColorB", HUD.Gear.TopColorB);
-    HUD.Gear.ColorR = ini.GetLongValue("HUD", "GearColorR", HUD.Gear.ColorR);
-    HUD.Gear.ColorG = ini.GetLongValue("HUD", "GearColorG", HUD.Gear.ColorG);
-    HUD.Gear.ColorB = ini.GetLongValue("HUD", "GearColorB", HUD.Gear.ColorB);
+    HUD.Gear.Enable = ini.GetBoolValue("HUD", "GearIndicator", gSettings.HUD.Gear.Enable);
+    HUD.Gear.XPos = ini.GetDoubleValue("HUD", "GearXpos", gSettings.HUD.Gear.XPos);
+    HUD.Gear.YPos = ini.GetDoubleValue("HUD", "GearYpos", gSettings.HUD.Gear.YPos);
+    HUD.Gear.Size = ini.GetDoubleValue("HUD", "GearSize", gSettings.HUD.Gear.Size);
+    HUD.Gear.TopColorR = ini.GetLongValue("HUD", "GearTopColorR", gSettings.HUD.Gear.TopColorR);
+    HUD.Gear.TopColorG = ini.GetLongValue("HUD", "GearTopColorG", gSettings.HUD.Gear.TopColorG);
+    HUD.Gear.TopColorB = ini.GetLongValue("HUD", "GearTopColorB", gSettings.HUD.Gear.TopColorB);
+    HUD.Gear.ColorR = ini.GetLongValue("HUD", "GearColorR", gSettings.HUD.Gear.ColorR);
+    HUD.Gear.ColorG = ini.GetLongValue("HUD", "GearColorG", gSettings.HUD.Gear.ColorG);
+    HUD.Gear.ColorB = ini.GetLongValue("HUD", "GearColorB", gSettings.HUD.Gear.ColorB);
 
-    HUD.ShiftMode.Enable = ini.GetBoolValue("HUD", "ShiftModeIndicator", true);
-    HUD.ShiftMode.XPos = ini.GetDoubleValue("HUD", "ShiftModeXpos", HUD.ShiftMode.XPos);
-    HUD.ShiftMode.YPos = ini.GetDoubleValue("HUD", "ShiftModeYpos", HUD.ShiftMode.YPos);
-    HUD.ShiftMode.Size = ini.GetDoubleValue("HUD", "ShiftModeSize", HUD.ShiftMode.Size);
-    HUD.ShiftMode.ColorR = ini.GetLongValue("HUD", "ShiftModeColorR", HUD.ShiftMode.ColorR);
-    HUD.ShiftMode.ColorG = ini.GetLongValue("HUD", "ShiftModeColorG", HUD.ShiftMode.ColorG);
-    HUD.ShiftMode.ColorB = ini.GetLongValue("HUD", "ShiftModeColorB", HUD.ShiftMode.ColorB);
+    HUD.ShiftMode.Enable = ini.GetBoolValue("HUD", "ShiftModeIndicator", gSettings.HUD.ShiftMode.Enable);
+    HUD.ShiftMode.XPos = ini.GetDoubleValue("HUD", "ShiftModeXpos", gSettings.HUD.ShiftMode.XPos);
+    HUD.ShiftMode.YPos = ini.GetDoubleValue("HUD", "ShiftModeYpos", gSettings.HUD.ShiftMode.YPos);
+    HUD.ShiftMode.Size = ini.GetDoubleValue("HUD", "ShiftModeSize", gSettings.HUD.ShiftMode.Size);
+    HUD.ShiftMode.ColorR = ini.GetLongValue("HUD", "ShiftModeColorR", gSettings.HUD.ShiftMode.ColorR);
+    HUD.ShiftMode.ColorG = ini.GetLongValue("HUD", "ShiftModeColorG", gSettings.HUD.ShiftMode.ColorG);
+    HUD.ShiftMode.ColorB = ini.GetLongValue("HUD", "ShiftModeColorB", gSettings.HUD.ShiftMode.ColorB);
 
-    HUD.Speedo.Speedo = ini.GetValue("HUD", "Speedo", HUD.Speedo.Speedo.c_str());
-    HUD.Speedo.ShowUnit = ini.GetBoolValue("HUD", "SpeedoShowUnit", HUD.Speedo.ShowUnit);
-    HUD.Speedo.XPos = ini.GetDoubleValue("HUD", "SpeedoXpos", HUD.Speedo.XPos);
-    HUD.Speedo.YPos = ini.GetDoubleValue("HUD", "SpeedoYpos", HUD.Speedo.YPos);
-    HUD.Speedo.Size = ini.GetDoubleValue("HUD", "SpeedoSize", HUD.Speedo.Size);
-    HUD.Speedo.ColorR = ini.GetLongValue("HUD", "SpeedoColorR", HUD.Speedo.ColorR);
-    HUD.Speedo.ColorG = ini.GetLongValue("HUD", "SpeedoColorG", HUD.Speedo.ColorG);
-    HUD.Speedo.ColorB = ini.GetLongValue("HUD", "SpeedoColorB", HUD.Speedo.ColorB);
+    HUD.Speedo.Speedo = ini.GetValue("HUD", "Speedo", gSettings.HUD.Speedo.Speedo.c_str());
+    HUD.Speedo.ShowUnit = ini.GetBoolValue("HUD", "SpeedoShowUnit", gSettings.HUD.Speedo.ShowUnit);
+    HUD.Speedo.XPos = ini.GetDoubleValue("HUD", "SpeedoXpos", gSettings.HUD.Speedo.XPos);
+    HUD.Speedo.YPos = ini.GetDoubleValue("HUD", "SpeedoYpos", gSettings.HUD.Speedo.YPos);
+    HUD.Speedo.Size = ini.GetDoubleValue("HUD", "SpeedoSize", gSettings.HUD.Speedo.Size);
+    HUD.Speedo.ColorR = ini.GetLongValue("HUD", "SpeedoColorR", gSettings.HUD.Speedo.ColorR);
+    HUD.Speedo.ColorG = ini.GetLongValue("HUD", "SpeedoColorG", gSettings.HUD.Speedo.ColorG);
+    HUD.Speedo.ColorB = ini.GetLongValue("HUD", "SpeedoColorB", gSettings.HUD.Speedo.ColorB);
 
-    HUD.RPMBar.Enable = ini.GetBoolValue("HUD", "EnableRPMIndicator", HUD.RPMBar.Enable);
-    HUD.RPMBar.XPos = ini.GetDoubleValue("HUD", "RPMIndicatorXpos", HUD.RPMBar.XPos);
-    HUD.RPMBar.YPos = ini.GetDoubleValue("HUD", "RPMIndicatorYpos", HUD.RPMBar.YPos);
-    HUD.RPMBar.XSz = ini.GetDoubleValue("HUD", "RPMIndicatorWidth", HUD.RPMBar.XSz);
-    HUD.RPMBar.YSz = ini.GetDoubleValue("HUD", "RPMIndicatorHeight", HUD.RPMBar.YSz);
-    HUD.RPMBar.Redline = ini.GetDoubleValue("HUD", "RPMIndicatorRedline", HUD.RPMBar.Redline);
+    HUD.RPMBar.Enable = ini.GetBoolValue("HUD", "EnableRPMIndicator", gSettings.HUD.RPMBar.Enable);
+    HUD.RPMBar.XPos = ini.GetDoubleValue("HUD", "RPMIndicatorXpos", gSettings.HUD.RPMBar.XPos);
+    HUD.RPMBar.YPos = ini.GetDoubleValue("HUD", "RPMIndicatorYpos", gSettings.HUD.RPMBar.YPos);
+    HUD.RPMBar.XSz = ini.GetDoubleValue("HUD", "RPMIndicatorWidth", gSettings.HUD.RPMBar.XSz);
+    HUD.RPMBar.YSz = ini.GetDoubleValue("HUD", "RPMIndicatorHeight", gSettings.HUD.RPMBar.YSz);
+    HUD.RPMBar.Redline = ini.GetDoubleValue("HUD", "RPMIndicatorRedline", gSettings.HUD.RPMBar.Redline);
 
-    HUD.RPMBar.BgR = ini.GetLongValue("HUD", "RPMIndicatorBackgroundR", HUD.RPMBar.BgR);
-    HUD.RPMBar.BgG = ini.GetLongValue("HUD", "RPMIndicatorBackgroundG", HUD.RPMBar.BgG);
-    HUD.RPMBar.BgB = ini.GetLongValue("HUD", "RPMIndicatorBackgroundB", HUD.RPMBar.BgB);
-    HUD.RPMBar.BgA = ini.GetLongValue("HUD", "RPMIndicatorBackgroundA", HUD.RPMBar.BgA);
+    HUD.RPMBar.BgR = ini.GetLongValue("HUD", "RPMIndicatorBackgroundR", gSettings.HUD.RPMBar.BgR);
+    HUD.RPMBar.BgG = ini.GetLongValue("HUD", "RPMIndicatorBackgroundG", gSettings.HUD.RPMBar.BgG);
+    HUD.RPMBar.BgB = ini.GetLongValue("HUD", "RPMIndicatorBackgroundB", gSettings.HUD.RPMBar.BgB);
+    HUD.RPMBar.BgA = ini.GetLongValue("HUD", "RPMIndicatorBackgroundA", gSettings.HUD.RPMBar.BgA);
 
-    HUD.RPMBar.FgR = ini.GetLongValue("HUD", "RPMIndicatorForegroundR", HUD.RPMBar.FgR);
-    HUD.RPMBar.FgG = ini.GetLongValue("HUD", "RPMIndicatorForegroundG", HUD.RPMBar.FgG);
-    HUD.RPMBar.FgB = ini.GetLongValue("HUD", "RPMIndicatorForegroundB", HUD.RPMBar.FgB);
-    HUD.RPMBar.FgA = ini.GetLongValue("HUD", "RPMIndicatorForegroundA", HUD.RPMBar.FgA);
+    HUD.RPMBar.FgR = ini.GetLongValue("HUD", "RPMIndicatorForegroundR", gSettings.HUD.RPMBar.FgR);
+    HUD.RPMBar.FgG = ini.GetLongValue("HUD", "RPMIndicatorForegroundG", gSettings.HUD.RPMBar.FgG);
+    HUD.RPMBar.FgB = ini.GetLongValue("HUD", "RPMIndicatorForegroundB", gSettings.HUD.RPMBar.FgB);
+    HUD.RPMBar.FgA = ini.GetLongValue("HUD", "RPMIndicatorForegroundA", gSettings.HUD.RPMBar.FgA);
 
-    HUD.RPMBar.RedlineR = ini.GetLongValue("HUD", "RPMIndicatorRedlineR", HUD.RPMBar.RedlineR);
-    HUD.RPMBar.RedlineG = ini.GetLongValue("HUD", "RPMIndicatorRedlineG", HUD.RPMBar.RedlineG);
-    HUD.RPMBar.RedlineB = ini.GetLongValue("HUD", "RPMIndicatorRedlineB", HUD.RPMBar.RedlineB);
-    HUD.RPMBar.RedlineA = ini.GetLongValue("HUD", "RPMIndicatorRedlineA", HUD.RPMBar.RedlineA);
+    HUD.RPMBar.RedlineR = ini.GetLongValue("HUD", "RPMIndicatorRedlineR", gSettings.HUD.RPMBar.RedlineR);
+    HUD.RPMBar.RedlineG = ini.GetLongValue("HUD", "RPMIndicatorRedlineG", gSettings.HUD.RPMBar.RedlineG);
+    HUD.RPMBar.RedlineB = ini.GetLongValue("HUD", "RPMIndicatorRedlineB", gSettings.HUD.RPMBar.RedlineB);
+    HUD.RPMBar.RedlineA = ini.GetLongValue("HUD", "RPMIndicatorRedlineA", gSettings.HUD.RPMBar.RedlineA);
 
-    HUD.RPMBar.RevLimitR = ini.GetLongValue("HUD", "RPMIndicatorRevlimitR", HUD.RPMBar.RevLimitR);
-    HUD.RPMBar.RevLimitG = ini.GetLongValue("HUD", "RPMIndicatorRevlimitG", HUD.RPMBar.RevLimitG);
-    HUD.RPMBar.RevLimitB = ini.GetLongValue("HUD", "RPMIndicatorRevlimitB", HUD.RPMBar.RevLimitB);
-    HUD.RPMBar.RevLimitA = ini.GetLongValue("HUD", "RPMIndicatorRevlimitA", HUD.RPMBar.RevLimitA);
+    HUD.RPMBar.RevLimitR = ini.GetLongValue("HUD", "RPMIndicatorRevlimitR", gSettings.HUD.RPMBar.RevLimitR);
+    HUD.RPMBar.RevLimitG = ini.GetLongValue("HUD", "RPMIndicatorRevlimitG", gSettings.HUD.RPMBar.RevLimitG);
+    HUD.RPMBar.RevLimitB = ini.GetLongValue("HUD", "RPMIndicatorRevlimitB", gSettings.HUD.RPMBar.RevLimitB);
+    HUD.RPMBar.RevLimitA = ini.GetLongValue("HUD", "RPMIndicatorRevlimitA", gSettings.HUD.RPMBar.RevLimitA);
 
-    HUD.DashIndicators.Enable = ini.GetBoolValue("HUD", "DashIndicators", HUD.DashIndicators.Enable);
-    HUD.DashIndicators.XPos = ini.GetDoubleValue("HUD", "DashIndicatorsXpos", HUD.DashIndicators.XPos);
-    HUD.DashIndicators.YPos = ini.GetDoubleValue("HUD", "DashIndicatorsYpos", HUD.DashIndicators.YPos);
-    HUD.DashIndicators.Size = ini.GetDoubleValue("HUD", "DashIndicatorsSize", HUD.DashIndicators.Size);
+    HUD.DashIndicators.Enable = ini.GetBoolValue("HUD", "DashIndicators", gSettings.HUD.DashIndicators.Enable);
+    HUD.DashIndicators.XPos = ini.GetDoubleValue("HUD", "DashIndicatorsXpos", gSettings.HUD.DashIndicators.XPos);
+    HUD.DashIndicators.YPos = ini.GetDoubleValue("HUD", "DashIndicatorsYpos", gSettings.HUD.DashIndicators.YPos);
+    HUD.DashIndicators.Size = ini.GetDoubleValue("HUD", "DashIndicatorsSize", gSettings.HUD.DashIndicators.Size);
 }
 #pragma warning(pop)

--- a/Gears/VehicleConfig.h
+++ b/Gears/VehicleConfig.h
@@ -34,6 +34,8 @@ public:
         float StallingRPM = 0.1f;
         float RPMDamage = 0.1f;
         float MisshiftDamage = 5.0f;
+        float CreepIdleThrottle = 0.1f;
+        float CreepIdleRPM = 0.1f;
     } MTParams;
 
     // [DRIVING_ASSISTS]

--- a/Gears/VehicleConfig.h
+++ b/Gears/VehicleConfig.h
@@ -29,9 +29,9 @@ public:
         float EngBrakeThreshold = 0.75f;
         // Clutch _lift_ distance
         float ClutchThreshold = 0.15f;
-        // Clutch _lift_ distance
-        float StallingThreshold = 0.35f;
-        float StallingRPM = 0.1f;
+        float StallingRPM = 0.09f;
+        float StallingRate = 3.75f;
+        float StallingSlip = 0.40f;
         float RPMDamage = 0.1f;
         float MisshiftDamage = 5.0f;
         float CreepIdleThrottle = 0.1f;

--- a/Gears/VehicleData.hpp
+++ b/Gears/VehicleData.hpp
@@ -36,6 +36,12 @@ enum class ABSType {
     ABS_ALT_OPTION,
 };
 
+enum class IgnitionState {
+    Off,
+    Stall,
+    On,
+};
+
 struct VehiclePeripherals {
     // "Peripherals"
     bool BlinkerLeft = false;
@@ -44,6 +50,7 @@ struct VehiclePeripherals {
     int BlinkerTicks = 0;
     bool LookBackRShoulder = false;
     int RadioStationIndex = 0;
+    IgnitionState IgnitionState = IgnitionState::Off;
 };
 
 enum class ShiftDirection {

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -1291,7 +1291,8 @@ void functionClutchCatch() {
 }
 
 void functionEngStall() {
-    const float stallRate = GAMEPLAY::GET_FRAME_TIME() * 3.33f;
+    const float stallRate = GAMEPLAY::GET_FRAME_TIME() * g_settings().MTParams.StallingRate;
+    const float stallSlip = g_settings().MTParams.StallingSlip;
 
     float minSpeed = g_settings().MTParams.StallingRPM * abs(g_vehData.mDriveMaxFlatVel / g_vehData.mGearRatios[g_vehData.mGearCurr]);
     float actualSpeed = g_vehData.mWheelAverageDrivenTyreSpeed;
@@ -1299,20 +1300,17 @@ void functionEngStall() {
     // Closer to idle speed = less buildup for stalling
     float speedDiffRatio = map(abs(minSpeed) - abs(actualSpeed), 0.0f, abs(minSpeed), 0.0f, 1.0f);
     speedDiffRatio = std::clamp(speedDiffRatio, 0.0f, 1.0f);
-    if (speedDiffRatio < 0.45f)
-        speedDiffRatio = 0.0f; //ignore if we're close-ish to idle
     
     bool clutchEngaged = !isClutchPressed();
-    bool stallEngaged = g_controls.ClutchVal < 1.0f - g_settings().MTParams.StallingThreshold;
 
-    // this thing is big when the clutch isnt pressed
-    float invClutch = 1.0f - g_controls.ClutchVal;
+    float clutchRatio = map(g_controls.ClutchVal, 1.0f - g_settings().MTParams.ClutchThreshold, 0.0f, 0.0f, 1.0f);
 
-    if (stallEngaged &&
-        g_vehData.mRPM < 0.25f && //engine actually has to idle
+    if (clutchEngaged &&
+        g_vehData.mRPM <= 0.201f && //engine actually has to idle
         abs(actualSpeed) < abs(minSpeed) &&
         VEHICLE::GET_IS_VEHICLE_ENGINE_RUNNING(g_playerVehicle)) {
-        float change = invClutch * speedDiffRatio * stallRate;
+        float finalClutchRatio = map(clutchRatio, stallSlip, 1.0f, 0.0f, 1.0f);
+        float change = finalClutchRatio * speedDiffRatio * stallRate;
         g_gearStates.StallProgress += change;
     }
     else if (g_gearStates.StallProgress > 0.0f) {
@@ -1329,11 +1327,14 @@ void functionEngStall() {
         }
         g_gearStates.StallProgress = 0.0f;
     }
+    if (g_gearStates.StallProgress < 0.0f) {
+        g_gearStates.StallProgress = 0.0f;
+    }
 
     // Simulate push-start
     // We'll just assume the ignition thing is in the "on" position.
     if (actualSpeed > minSpeed && !VEHICLE::GET_IS_VEHICLE_ENGINE_RUNNING(g_playerVehicle) &&
-        stallEngaged) {
+        clutchEngaged) {
         VEHICLE::SET_VEHICLE_ENGINE_ON(g_playerVehicle, true, true, true);
     }
 

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -150,6 +150,19 @@ void functionDash() {
     bool abs = DashLights::LastAbsTime + DashLights::LightDuration >= GAMEPLAY::GET_GAME_TIMER();
     data.ABSLight |= abs;
 
+    if (g_peripherals.IgnitionState == IgnitionState::Stall) {
+        // data.indicator_left = true;
+        // data.indicator_right = true;
+        // data.handbrakeLight = true;
+        data.engineLight = true;
+        data.ABSLight = true;
+        data.petrolLight = true;
+        data.oilLight = true;
+        // data.headlights = true;
+        // data.fullBeam = true;
+        data.batteryLight = true;
+    }
+
     DashHook_SetData(data);
 }
 
@@ -236,6 +249,14 @@ void update_vehicle() {
 
     if (vehAvail) {
         g_vehData.Update(); // Update before doing anything else
+
+        if (VEHICLE::GET_IS_VEHICLE_ENGINE_RUNNING(g_playerVehicle)) {
+            g_peripherals.IgnitionState = IgnitionState::On;
+        }
+        else if (!(g_peripherals.IgnitionState == IgnitionState::Stall)) {
+            // Engine off, but not stalled
+            g_peripherals.IgnitionState = IgnitionState::Off;
+        }
         functionDash();
     }
     if (g_playerVehicle != g_lastPlayerVehicle && vehAvail) {
@@ -1302,6 +1323,9 @@ void functionEngStall() {
     if (g_gearStates.StallProgress > 1.0f) {
         if (VEHICLE::GET_IS_VEHICLE_ENGINE_RUNNING(g_playerVehicle)) {
             VEHICLE::SET_VEHICLE_ENGINE_ON(g_playerVehicle, false, true, true);
+            g_controls.PlayFFBCollision(g_settings().Wheel.FFB.DetailLim / 2);
+            CONTROLS::SET_PAD_SHAKE(0, 100, 255);
+            g_peripherals.IgnitionState = IgnitionState::Stall;
         }
         g_gearStates.StallProgress = 0.0f;
     }

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -1228,13 +1228,14 @@ bool isSkidding(float threshold) {
 ///////////////////////////////////////////////////////////////////////////////
 
 void functionClutchCatch() {
-    const float idleThrottle = 0.24f;
+    const float idleThrottle = g_settings().MTParams.CreepIdleThrottle;
+    const float idleRPM = g_settings().MTParams.CreepIdleRPM;
 
     float clutchRatio = map(g_controls.ClutchVal, 1.0f - g_settings().MTParams.ClutchThreshold, 0.0f, 0.0f, 1.0f);
     clutchRatio = std::clamp(clutchRatio, 0.0f, 1.0f);
 
     bool clutchEngaged = !isClutchPressed();
-    float minSpeed = 0.2f * (g_vehData.mDriveMaxFlatVel / g_vehData.mGearRatios[g_vehData.mGearCurr]);
+    float minSpeed = idleRPM * (g_vehData.mDriveMaxFlatVel / g_vehData.mGearRatios[g_vehData.mGearCurr]);
     float expectedSpeed = g_vehData.mRPM * (g_vehData.mDriveMaxFlatVel / g_vehData.mGearRatios[g_vehData.mGearCurr]) * clutchRatio;
     float actualSpeed = g_vehData.mWheelAverageDrivenTyreSpeed;
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -10,6 +10,9 @@ compatible, aside from the following:
 
 * Engine and transmission
   * Add alternate automatic transmission mode, by [Nyconing](https://github.com/Nyconing)
+  * Add visual and physical feedback to stalling
+  * Improve stalling with additional settings
+  * Improve clutch creep with additional settings
   * Fix engine revving when locked up due to direction
   * Fix delta-gear ratio for automatic transission downshifts
   * Fix ABS affecting automatic transmission shifting
@@ -35,17 +38,19 @@ compatible, aside from the following:
   * Fix CustomSteering deactivation timing for better ACSPatch control
 * UI
   * Improve menu layout (hopefully)
-  * Add DashHook support for ABS light
+  * Add DashHook support for ABS light and other warning lights when stalled
   * Add color options for speedo, gear and shift mode UI elements
   * Add option to turn off UI font outlines
   * Show enabled but untriggered assists as black on dashboard indicators
   * Show triggered lights for at least 300 milliseconds before turning off
+  * Show stalling progress in RPM bar
   * Fix throttle-based TCS not firing dashboard indicator icon
 * General
   * Add UDP telemetry support for programs like SimHub. DiRT4 thanks to [guilhermelimak](https://github.com/guilhermelimak)
   * Add animation syncing!
   * Fix control acquire/release timing (now only when ped has control of car)
   * Fix controller engine on/off hold trigger
+  * Fix an issue for VehicleConfig, where an unspecified option used the class defaults instead of the active main settings
 
 ## 4.7.1
 


### PR DESCRIPTION
Closes #78

* Adds visual and physical cues for engine stalling
  * RPM bar shows stall progress, ranging from 0.2 (idle) to 0.0 (stalled), also changes color
  * A stalled car now turns on all dashboard warning lights
  * Shakes the wheel with a collision effect (half the force of the max detail force)
  * Shakes the gamepad briefly
* Clutch creep parameters are now user-adjustable
  * Base RPM for speed
  * Throttle (how fast/strong the effect is)
* Stalling is improved, more stalling parameters are now user-adjustable
  * StallingThreshold replaced by clutch slip mechanism
  * Speed factor of which the stalling progress increases, is user-configurable
* VehicleConfig related fixes, where an unspecified option used the class defaults instead of the active main settings.