### PR TITLE
Bugfix/tracked changes

### DIFF
--- a/Gears/AWD.cpp
+++ b/Gears/AWD.cpp
@@ -215,10 +215,12 @@ STransferInfo GetOversteerTransfer(float driveBiasF, float biasMax, DrivingAssis
     if (abs(oversteerDeg) > g_settings().DriveAssists.AWD.OversteerMin &&
         ENTITY::GET_ENTITY_SPEED(g_playerVehicle) > 1.0f) {
         float throttle = VExt::GetThrottle(g_playerVehicle);
+        float osMin = g_settings().DriveAssists.AWD.OversteerMin;
+        float osMax = g_settings().DriveAssists.AWD.OversteerMax;
 
         transferRatio = map(
             oversteerDeg,
-            g_settings().DriveAssists.AWD.OversteerMin, g_settings().DriveAssists.AWD.OversteerMax,
+            osMin, osMax,
             0.0f, 1.0f) * throttle;
         transferRatio = std::clamp(transferRatio, 0.0f, 1.0f);
 
@@ -237,10 +239,12 @@ STransferInfo GetUndersteerTransfer(float driveBiasF, float biasMax, DrivingAssi
     if (espData.UndersteerAngleValid &&
         understeerDeg > g_settings().DriveAssists.AWD.UndersteerMin) {
         float throttle = VExt::GetThrottle(g_playerVehicle);
+        float usMin = g_settings().DriveAssists.AWD.UndersteerMin;
+        float usMax = g_settings().DriveAssists.AWD.UndersteerMax;
 
         transferRatio = map(
             understeerDeg,
-            g_settings().DriveAssists.AWD.UndersteerMin, g_settings().DriveAssists.AWD.UndersteerMax,
+            usMin, usMax,
             0.0f, 1.0f) * throttle;
         transferRatio = std::clamp(transferRatio, 0.0f, 1.0f);
 

--- a/Gears/Camera.cpp
+++ b/Gears/Camera.cpp
@@ -479,9 +479,10 @@ void updateRotationCameraMovement() {
 
     float velComponent = travelDir * g_settings().Misc.Camera.Movement.RotationDirectionMult;
     float rotComponent = rotationVelocity.z * g_settings().Misc.Camera.Movement.RotationRotationMult;
+    float rotMax = deg2rad(g_settings().Misc.Camera.Movement.RotationMaxAngle);
     float totalMove = std::clamp(velComponent + rotComponent,
-        -deg2rad(g_settings().Misc.Camera.Movement.RotationMaxAngle),
-        deg2rad(g_settings().Misc.Camera.Movement.RotationMaxAngle));
+        -rotMax,
+        rotMax);
     float newAngle = -rad2deg(totalMove);
 
     if (speedVector.y < 3.0f) {
@@ -529,10 +530,11 @@ void updateLongitudinalCameraMovement() {
         mappedAccel = map(gForce, -deadzone, -10.0f, 0.0f, -10.0f);
         mult = g_settings().Misc.Camera.Movement.LongForwardMult;
     }
-
+    float longBwLim = g_settings().Misc.Camera.Movement.LongBackwardLimit;
+    float longFwLim = g_settings().Misc.Camera.Movement.LongForwardLimit;
     float accelVal = 
         std::clamp(-mappedAccel * mult,
-            -g_settings().Misc.Camera.Movement.LongBackwardLimit,
-            g_settings().Misc.Camera.Movement.LongForwardLimit);
+            -longBwLim,
+            longFwLim);
     accelMoveFwd = lerp(accelMoveFwd, accelVal, lerpF); // just for smoothness
 }

--- a/Gears/DrivingAssists.cpp
+++ b/Gears/DrivingAssists.cpp
@@ -201,21 +201,32 @@ std::vector<float> DrivingAssists::GetESPBrakes(ESPData espData, LSDData lsdData
         avgAngle_ = avgAngle;
     }
     float oversteerAngleDeg = abs(rad2deg(espData.OversteerAngle));
+    float overMin = g_settings().DriveAssists.ESP.OverMin;
+    float overMax = g_settings().DriveAssists.ESP.OverMax;
+    float overMinComp = g_settings().DriveAssists.ESP.OverMinComp;
+    float overMaxComp = g_settings().DriveAssists.ESP.OverMaxComp;
     float oversteerComp = map(oversteerAngleDeg,
-        g_settings().DriveAssists.ESP.OverMin, g_settings().DriveAssists.ESP.OverMax,
-        g_settings().DriveAssists.ESP.OverMinComp, g_settings().DriveAssists.ESP.OverMaxComp);
+        overMin, overMax,
+        overMinComp, overMaxComp);
 
     float oversteerAdd = handlingBrakeForce * oversteerComp;
 
+
     float oversteerRearAdd = handlingBrakeForce * map(
-        oversteerAngleDeg, g_settings().DriveAssists.ESP.OverMax, g_settings().DriveAssists.ESP.OverMax * 2.0f,
-        g_settings().DriveAssists.ESP.OverMinComp, g_settings().DriveAssists.ESP.OverMaxComp);
-    oversteerRearAdd = std::clamp(oversteerRearAdd, 0.0f, g_settings().DriveAssists.ESP.OverMaxComp);
+        oversteerAngleDeg, overMax, overMax * 2.0f,
+        overMinComp, overMaxComp);
+    oversteerRearAdd = std::clamp(oversteerRearAdd, 0.0f, overMaxComp);
 
     float understeerAngleDeg(abs(rad2deg(espData.UndersteerAngle)));
+
+    float underMin = g_settings().DriveAssists.ESP.UnderMin;
+    float underMax = g_settings().DriveAssists.ESP.UnderMax;
+    float underMinComp = g_settings().DriveAssists.ESP.UnderMinComp;
+    float underMaxComp = g_settings().DriveAssists.ESP.UnderMaxComp;
+
     float understeerComp = map(understeerAngleDeg,
-        g_settings().DriveAssists.ESP.UnderMin, g_settings().DriveAssists.ESP.UnderMax,
-        g_settings().DriveAssists.ESP.UnderMinComp, g_settings().DriveAssists.ESP.UnderMaxComp);
+        underMin, underMax,
+        underMinComp, underMaxComp);
 
     float understeerAdd = handlingBrakeForce * understeerComp;
 

--- a/Gears/ScriptMenu.cpp
+++ b/Gears/ScriptMenu.cpp
@@ -521,20 +521,26 @@ std::vector<std::string> formatVehicleConfig(const VehicleConfig& config) {
     if (shiftAssist.empty())
         shiftAssist = "None";
 
+    EShiftMode shiftMode = config.MTOptions.ShiftMode;
+    bool clutchCreep = config.MTOptions.ClutchCreep;
+    int tcsMode = config.DriveAssists.TCS.Mode;
+    bool espEn = config.DriveAssists.ESP.Enable;
+    bool lsdEn = config.DriveAssists.LSD.Enable;
+
     std::vector<std::string> extras{
         fmt::format("{}", config.Description),
         "Compatible cars:",
         fmt::format("\tModels: {}", modelNames),
         fmt::format("\tPlates: {}", plates),
         "Shifting options:",
-        fmt::format("\tShift mode: {}", gearboxModes[static_cast<int>(config.MTOptions.ShiftMode)]),
-        fmt::format("\tClutch creep: {}", config.MTOptions.ClutchCreep),
+        fmt::format("\tShift mode: {}", gearboxModes[shiftMode]),
+        fmt::format("\tClutch creep: {}", clutchCreep),
         fmt::format("\tSequential assist: {}", shiftAssist),
         "Driving assists:",
         fmt::format("\tABS: {}", absStrings[absMode]),
-        fmt::format("\tTCS: {}", tcsStrings[config.DriveAssists.TCS.Mode]),
-        fmt::format("\tESP: {}", config.DriveAssists.ESP.Enable ? "Yes" : "No"),
-        fmt::format("\tLSD: {}", config.DriveAssists.LSD.Enable ? "Yes" : "No"),
+        fmt::format("\tTCS: {}", tcsStrings[tcsMode]),
+        fmt::format("\tESP: {}", espEn ? "Yes" : "No"),
+        fmt::format("\tLSD: {}", lsdEn ? "Yes" : "No"),
         "Steering wheel:",
         fmt::format("\tSoft lock: {:.0f}", config.Steering.Wheel.SoftLock)
     };

--- a/Gears/Util/MathExt.h
+++ b/Gears/Util/MathExt.h
@@ -37,15 +37,18 @@ T avg(std::vector<T, A> const& vec) {
     return average / static_cast<T>(vec.size());
 }
 
-template <typename T, typename = typename std::enable_if<std::is_floating_point<T>::value, T>::type>
+#pragma warning(push)
+#pragma warning(disable: 4244)
+template <typename T>
 constexpr T rad2deg(T rad) {
     return static_cast<T>(static_cast<double>(rad) * (180.0 / M_PI));
 }
 
-template <typename T, typename = typename std::enable_if<std::is_floating_point<T>::value, T>::type>
+template <typename T>
 constexpr T deg2rad(T deg) {
     return static_cast<T>(static_cast<double>(deg) * M_PI / 180.0);
 }
+#pragma warning(pop)
 
 template <typename T>
 T map(T x, T in_min, T in_max, T out_min, T out_max) {

--- a/Gears/VehicleConfig.cpp
+++ b/Gears/VehicleConfig.cpp
@@ -114,7 +114,6 @@ void VehicleConfig::LoadSettings(const std::string& file) {
 
     // [MT_OPTIONS]
     MTOptions.ShiftMode.Set(static_cast<EShiftMode>(ini.GetLongValue("MT_OPTIONS", "ShiftMode", baseConfig.MTOptions.ShiftMode)));
-
     LOAD_VAL("MT_OPTIONS", "ClutchCatching", MTOptions.ClutchCreep);
     LOAD_VAL("MT_OPTIONS", "ClutchShiftingH", MTOptions.ClutchShiftH);
     LOAD_VAL("MT_OPTIONS", "ClutchShiftingS", MTOptions.ClutchShiftS);
@@ -165,7 +164,7 @@ void VehicleConfig::LoadSettings(const std::string& file) {
     LOAD_VAL("DRIVING_ASSISTS",   "AWDUseUndersteer", DriveAssists.AWD.UseUndersteer);
     LOAD_VAL("DRIVING_ASSISTS", "AWDUndersteerMin", DriveAssists.AWD.UndersteerMin);
     LOAD_VAL("DRIVING_ASSISTS", "AWDUndersteerMax", DriveAssists.AWD.UndersteerMax);
-    DriveAssists.AWD.SpecialFlags      = ini.GetLongValue  ("DRIVING_ASSISTS",   "AWDSpecialFlags", DriveAssists.AWD.SpecialFlags);
+    DriveAssists.AWD.SpecialFlags.Set(ini.GetLongValue("DRIVING_ASSISTS", "AWDSpecialFlags", DriveAssists.AWD.SpecialFlags));
 
     // [SHIFT_OPTIONS]
     LOAD_VAL("SHIFT_OPTIONS", "UpshiftCut", ShiftOptions.UpshiftCut);

--- a/Gears/VehicleConfig.cpp
+++ b/Gears/VehicleConfig.cpp
@@ -11,10 +11,13 @@
         __FUNCTION__, operation, result); \
     }
 
-#define SET_VALUE(section, key, option) \
-    if (mBaseConfig == this || option != mBaseConfig->option) { \
+#define SAVE_VAL(section, key, option) \
+    if (mBaseConfig == this || option != mBaseConfig->option || option.Changed()) { \
         SetValue(ini, section, key, option); \
     }
+
+#define LOAD_VAL(section, key, option) \
+    option.Set(GetValue(ini, section, key, baseConfig.option)); \
 
 void SetValue(CSimpleIniA & ini, const char* section, const char* key, int val) {
     ini.SetLongValue(section, key, val);
@@ -30,6 +33,22 @@ void SetValue(CSimpleIniA & ini, const char* section, const char* key, bool val)
 
 void SetValue(CSimpleIniA & ini, const char* section, const char* key, float val) {
     ini.SetDoubleValue(section, key, static_cast<double>(val));
+}
+
+int GetValue(CSimpleIniA& ini, const char* section, const char* key, int val) {
+    return ini.GetLongValue(section, key, val);
+}
+
+std::string GetValue(CSimpleIniA& ini, const char* section, const char* key, std::string val) {
+    return ini.GetValue(section, key, val.c_str());
+}
+
+bool GetValue(CSimpleIniA& ini, const char* section, const char* key, bool val) {
+    return ini.GetBoolValue(section, key, val);
+}
+
+float GetValue(CSimpleIniA& ini, const char* section, const char* key, float val) {
+    return static_cast<float>(ini.GetDoubleValue(section, key, val));
 }
 
 EShiftMode Next(EShiftMode mode) {
@@ -54,7 +73,7 @@ void VehicleConfig::LoadSettings(const std::string& file) {
         pConfig = this;
     }
 
-    const auto& gSettings = *pConfig;
+    auto& baseConfig = *pConfig;
 
     CSimpleIniA ini;
     ini.SetUnicode();
@@ -94,117 +113,117 @@ void VehicleConfig::LoadSettings(const std::string& file) {
     Description = ini.GetValue("ID", "Description", "No description.");
 
     // [MT_OPTIONS]
-    MTOptions.ShiftMode =
-        static_cast<EShiftMode>(ini.GetLongValue("MT_OPTIONS", "ShiftMode", static_cast<int>(gSettings.MTOptions.ShiftMode)));
-    MTOptions.ClutchCreep = ini.GetBoolValue("MT_OPTIONS", "ClutchCatching", gSettings.MTOptions.ClutchCreep);
-    MTOptions.ClutchShiftH = ini.GetBoolValue("MT_OPTIONS", "ClutchShiftingH", gSettings.MTOptions.ClutchShiftH);
-    MTOptions.ClutchShiftS = ini.GetBoolValue("MT_OPTIONS", "ClutchShiftingS", gSettings.MTOptions.ClutchShiftS);
+    MTOptions.ShiftMode.Set(static_cast<EShiftMode>(ini.GetLongValue("MT_OPTIONS", "ShiftMode", baseConfig.MTOptions.ShiftMode)));
+
+    LOAD_VAL("MT_OPTIONS", "ClutchCatching", MTOptions.ClutchCreep);
+    LOAD_VAL("MT_OPTIONS", "ClutchShiftingH", MTOptions.ClutchShiftH);
+    LOAD_VAL("MT_OPTIONS", "ClutchShiftingS", MTOptions.ClutchShiftS);
 
     // [MT_PARAMS]
-    MTParams.ClutchThreshold = ini.GetDoubleValue("MT_PARAMS", "ClutchCatchpoint", gSettings.MTParams.ClutchThreshold);
-    MTParams.StallingRPM = ini.GetDoubleValue("MT_PARAMS", "StallingRPM", gSettings.MTParams.StallingRPM);
-    MTParams.StallingRate = ini.GetDoubleValue("MT_PARAMS", "StallingRate", gSettings.MTParams.StallingRate);
-    MTParams.StallingSlip = ini.GetDoubleValue("MT_PARAMS", "StallingSlip", gSettings.MTParams.StallingSlip);
-    MTParams.RPMDamage = ini.GetDoubleValue("MT_PARAMS", "RPMDamage", gSettings.MTParams.RPMDamage);
-    MTParams.MisshiftDamage = ini.GetDoubleValue("MT_PARAMS", "MisshiftDamage", gSettings.MTParams.MisshiftDamage);
-    MTParams.EngBrakePower = ini.GetDoubleValue("MT_PARAMS", "EngBrakePower", gSettings.MTParams.EngBrakePower);
-    MTParams.EngBrakeThreshold = ini.GetDoubleValue("MT_PARAMS", "EngBrakeThreshold", gSettings.MTParams.EngBrakeThreshold);
-    MTParams.CreepIdleThrottle = ini.GetDoubleValue("MT_PARAMS", "CreepIdleThrottle", gSettings.MTParams.CreepIdleThrottle);
-    MTParams.CreepIdleRPM = ini.GetDoubleValue("MT_PARAMS", "CreepIdleRPM", gSettings.MTParams.CreepIdleRPM);
+    LOAD_VAL("MT_PARAMS", "ClutchCatchpoint", MTParams.ClutchThreshold);
+    LOAD_VAL("MT_PARAMS", "StallingRPM", MTParams.StallingRPM);
+    LOAD_VAL("MT_PARAMS", "StallingRate", MTParams.StallingRate);
+    LOAD_VAL("MT_PARAMS", "StallingSlip", MTParams.StallingSlip);
+    LOAD_VAL("MT_PARAMS", "RPMDamage", MTParams.RPMDamage);
+    LOAD_VAL("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
+    LOAD_VAL("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);
+    LOAD_VAL("MT_PARAMS", "EngBrakeThreshold", MTParams.EngBrakeThreshold);
+    LOAD_VAL("MT_PARAMS", "CreepIdleThrottle", MTParams.CreepIdleThrottle);
+    LOAD_VAL("MT_PARAMS", "CreepIdleRPM", MTParams.CreepIdleRPM);
 
     // [DRIVING_ASSISTS]
-    DriveAssists.ABS.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ABS", gSettings.DriveAssists.ABS.Enable);
-    DriveAssists.ABS.Filter = ini.GetBoolValue("DRIVING_ASSISTS", "ABSFilter", gSettings.DriveAssists.ABS.Filter);
-    DriveAssists.TCS.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "TCS", gSettings.DriveAssists.TCS.Enable);
-    DriveAssists.TCS.Mode = ini.GetLongValue("DRIVING_ASSISTS", "TCSMode", gSettings.DriveAssists.TCS.Mode);
-    DriveAssists.TCS.SlipMax = ini.GetDoubleValue("DRIVING_ASSISTS", "TCSSlipMax", gSettings.DriveAssists.TCS.SlipMax);
-    DriveAssists.ESP.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "ESP", gSettings.DriveAssists.ESP.Enable);
-    DriveAssists.ESP.OverMin = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMin", gSettings.DriveAssists.ESP.OverMin);
-    DriveAssists.ESP.OverMax = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMax", gSettings.DriveAssists.ESP.OverMax);
-    DriveAssists.ESP.OverMinComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMinComp", gSettings.DriveAssists.ESP.OverMinComp);
-    DriveAssists.ESP.OverMaxComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPOverMaxComp", gSettings.DriveAssists.ESP.OverMaxComp);
-    DriveAssists.ESP.UnderMin = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMin", gSettings.DriveAssists.ESP.UnderMin);
-    DriveAssists.ESP.UnderMax = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMax", gSettings.DriveAssists.ESP.UnderMax);
-    DriveAssists.ESP.UnderMinComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMinComp", gSettings.DriveAssists.ESP.UnderMinComp);
-    DriveAssists.ESP.UnderMaxComp = ini.GetDoubleValue("DRIVING_ASSISTS", "ESPUnderMaxComp", gSettings.DriveAssists.ESP.UnderMaxComp);
+    LOAD_VAL("DRIVING_ASSISTS", "ABS", DriveAssists.ABS.Enable);
+    LOAD_VAL("DRIVING_ASSISTS", "ABSFilter", DriveAssists.ABS.Filter);
+    LOAD_VAL("DRIVING_ASSISTS", "TCS", DriveAssists.TCS.Enable);
+    LOAD_VAL("DRIVING_ASSISTS", "TCSMode", DriveAssists.TCS.Mode);
+    LOAD_VAL("DRIVING_ASSISTS", "TCSSlipMax", DriveAssists.TCS.SlipMax);
+    LOAD_VAL("DRIVING_ASSISTS", "ESP", DriveAssists.ESP.Enable);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPOverMin", DriveAssists.ESP.OverMin);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPOverMax", DriveAssists.ESP.OverMax);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPOverMinComp", DriveAssists.ESP.OverMinComp);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPOverMaxComp", DriveAssists.ESP.OverMaxComp);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPUnderMin", DriveAssists.ESP.UnderMin);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPUnderMax", DriveAssists.ESP.UnderMax);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPUnderMinComp", DriveAssists.ESP.UnderMinComp);
+    LOAD_VAL("DRIVING_ASSISTS", "ESPUnderMaxComp", DriveAssists.ESP.UnderMaxComp);
 
-    DriveAssists.LSD.Enable = ini.GetBoolValue("DRIVING_ASSISTS", "LSD", gSettings.DriveAssists.LSD.Enable);
-    DriveAssists.LSD.Viscosity = ini.GetDoubleValue("DRIVING_ASSISTS", "LSDViscosity", gSettings.DriveAssists.LSD.Viscosity);
+    LOAD_VAL("DRIVING_ASSISTS", "LSD", DriveAssists.LSD.Enable);
+    LOAD_VAL("DRIVING_ASSISTS", "LSDViscosity", DriveAssists.LSD.Viscosity);
 
-    DriveAssists.AWD.Enable            = ini.GetBoolValue("DRIVING_ASSISTS",   "AWD", gSettings.DriveAssists.AWD.Enable);
-    DriveAssists.AWD.BiasAtMaxTransfer = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDBiasAtMaxTransfer", gSettings.DriveAssists.AWD.BiasAtMaxTransfer);
-    DriveAssists.AWD.UseCustomBaseBias = ini.GetBoolValue("DRIVING_ASSISTS",   "AWDUseCustomBaseBias", gSettings.DriveAssists.AWD.UseCustomBaseBias);
-    DriveAssists.AWD.CustomBaseBias    = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDCustomBaseBias", gSettings.DriveAssists.AWD.CustomBaseBias);
-    DriveAssists.AWD.CustomMin         = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDCustomMin", gSettings.DriveAssists.AWD.CustomMin);
-    DriveAssists.AWD.CustomMax         = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDCustomMax", gSettings.DriveAssists.AWD.CustomMax);
-    DriveAssists.AWD.UseTraction       = ini.GetBoolValue("DRIVING_ASSISTS",   "AWDUseTraction", gSettings.DriveAssists.AWD.UseTraction);
-    DriveAssists.AWD.TractionLossMin   = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDTractionLossMin", gSettings.DriveAssists.AWD.TractionLossMin);
-    DriveAssists.AWD.TractionLossMax   = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDTractionLossMax", gSettings.DriveAssists.AWD.TractionLossMax);
-    DriveAssists.AWD.UseOversteer      = ini.GetBoolValue("DRIVING_ASSISTS",   "AWDUseOversteer", gSettings.DriveAssists.AWD.UseOversteer);
-    DriveAssists.AWD.OversteerMin      = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDOversteerMin", gSettings.DriveAssists.AWD.OversteerMin);
-    DriveAssists.AWD.OversteerMax      = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDOversteerMax", gSettings.DriveAssists.AWD.OversteerMax);
-    DriveAssists.AWD.UseUndersteer     = ini.GetBoolValue("DRIVING_ASSISTS",   "AWDUseUndersteer", gSettings.DriveAssists.AWD.UseUndersteer);
-    DriveAssists.AWD.UndersteerMin     = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDUndersteerMin", gSettings.DriveAssists.AWD.UndersteerMin);
-    DriveAssists.AWD.UndersteerMax     = ini.GetDoubleValue("DRIVING_ASSISTS", "AWDUndersteerMax", gSettings.DriveAssists.AWD.UndersteerMax);
-    DriveAssists.AWD.SpecialFlags      = ini.GetLongValue("DRIVING_ASSISTS",   "AWDSpecialFlags", gSettings.DriveAssists.AWD.SpecialFlags);
+    LOAD_VAL("DRIVING_ASSISTS",   "AWD", DriveAssists.AWD.Enable);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDBiasAtMaxTransfer", DriveAssists.AWD.BiasAtMaxTransfer);
+    LOAD_VAL("DRIVING_ASSISTS",   "AWDUseCustomBaseBias", DriveAssists.AWD.UseCustomBaseBias);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDCustomBaseBias", DriveAssists.AWD.CustomBaseBias);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDCustomMin", DriveAssists.AWD.CustomMin);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDCustomMax", DriveAssists.AWD.CustomMax);
+    LOAD_VAL("DRIVING_ASSISTS",   "AWDUseTraction", DriveAssists.AWD.UseTraction);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDTractionLossMin", DriveAssists.AWD.TractionLossMin);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDTractionLossMax", DriveAssists.AWD.TractionLossMax);
+    LOAD_VAL("DRIVING_ASSISTS",   "AWDUseOversteer", DriveAssists.AWD.UseOversteer);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDOversteerMin", DriveAssists.AWD.OversteerMin);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDOversteerMax", DriveAssists.AWD.OversteerMax);
+    LOAD_VAL("DRIVING_ASSISTS",   "AWDUseUndersteer", DriveAssists.AWD.UseUndersteer);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDUndersteerMin", DriveAssists.AWD.UndersteerMin);
+    LOAD_VAL("DRIVING_ASSISTS", "AWDUndersteerMax", DriveAssists.AWD.UndersteerMax);
+    DriveAssists.AWD.SpecialFlags      = ini.GetLongValue  ("DRIVING_ASSISTS",   "AWDSpecialFlags", DriveAssists.AWD.SpecialFlags);
 
     // [SHIFT_OPTIONS]
-    ShiftOptions.UpshiftCut = ini.GetBoolValue("SHIFT_OPTIONS", "UpshiftCut", gSettings.ShiftOptions.UpshiftCut);
-    ShiftOptions.DownshiftBlip = ini.GetBoolValue("SHIFT_OPTIONS", "DownshiftBlip", gSettings.ShiftOptions.DownshiftBlip);
-    ShiftOptions.ClutchRateMult = ini.GetDoubleValue("SHIFT_OPTIONS", "ClutchRateMult", gSettings.ShiftOptions.ClutchRateMult);
-    ShiftOptions.RPMTolerance = ini.GetDoubleValue("SHIFT_OPTIONS", "RPMTolerance", gSettings.ShiftOptions.RPMTolerance);
+    LOAD_VAL("SHIFT_OPTIONS", "UpshiftCut", ShiftOptions.UpshiftCut);
+    LOAD_VAL("SHIFT_OPTIONS", "DownshiftBlip", ShiftOptions.DownshiftBlip);
+    LOAD_VAL("SHIFT_OPTIONS", "ClutchRateMult", ShiftOptions.ClutchRateMult);
+    LOAD_VAL("SHIFT_OPTIONS", "RPMTolerance", ShiftOptions.RPMTolerance);
 
     // [AUTO_PARAMS]
-    AutoParams.UpshiftLoad = ini.GetDoubleValue("AUTO_PARAMS", "UpshiftLoad", gSettings.AutoParams.UpshiftLoad);
-    AutoParams.DownshiftLoad = ini.GetDoubleValue("AUTO_PARAMS", "DownshiftLoad", gSettings.AutoParams.DownshiftLoad);
-    AutoParams.NextGearMinRPM = ini.GetDoubleValue("AUTO_PARAMS", "NextGearMinRPM", gSettings.AutoParams.NextGearMinRPM);
-    AutoParams.CurrGearMinRPM = ini.GetDoubleValue("AUTO_PARAMS", "CurrGearMinRPM", gSettings.AutoParams.CurrGearMinRPM);
-    AutoParams.EcoRate = ini.GetDoubleValue("AUTO_PARAMS", "EcoRate", gSettings.AutoParams.EcoRate);
-    AutoParams.DownshiftTimeoutMult = ini.GetDoubleValue("AUTO_PARAMS", "DownshiftTimeoutMult", gSettings.AutoParams.DownshiftTimeoutMult);
-    AutoParams.UsingATCU = ini.GetBoolValue("AUTO_PARAMS", "UsingATCU", gSettings.AutoParams.UsingATCU);
+    LOAD_VAL("AUTO_PARAMS", "UpshiftLoad", AutoParams.UpshiftLoad);
+    LOAD_VAL("AUTO_PARAMS", "DownshiftLoad", AutoParams.DownshiftLoad);
+    LOAD_VAL("AUTO_PARAMS", "NextGearMinRPM", AutoParams.NextGearMinRPM);
+    LOAD_VAL("AUTO_PARAMS", "CurrGearMinRPM", AutoParams.CurrGearMinRPM);
+    LOAD_VAL("AUTO_PARAMS", "EcoRate", AutoParams.EcoRate);
+    LOAD_VAL("AUTO_PARAMS", "DownshiftTimeoutMult", AutoParams.DownshiftTimeoutMult);
+    LOAD_VAL("AUTO_PARAMS", "UsingATCU", AutoParams.UsingATCU);
 
     //[STEERING_OVERRIDE]
-    Steering.CustomSteering.UseCustomLock = ini.GetBoolValue("STEERING", "CSUseCustomLock", Steering.CustomSteering.UseCustomLock);
-    Steering.CustomSteering.SoftLock = ini.GetDoubleValue("STEERING", "CSSoftLock", Steering.CustomSteering.SoftLock);
-    Steering.CustomSteering.SteeringMult = ini.GetDoubleValue("STEERING", "CSSteeringMult", Steering.CustomSteering.SteeringMult);
+    LOAD_VAL("STEERING", "CSUseCustomLock", Steering.CustomSteering.UseCustomLock);
+    LOAD_VAL("STEERING", "CSSoftLock", Steering.CustomSteering.SoftLock);
+    LOAD_VAL("STEERING", "CSSteeringMult", Steering.CustomSteering.SteeringMult);
 
-    Steering.Wheel.SoftLock = ini.GetDoubleValue("STEERING", "WSoftLock", Steering.Wheel.SoftLock);
-    Steering.Wheel.SteeringMult = ini.GetDoubleValue("STEERING", "WSteeringMult", Steering.Wheel.SteeringMult);
+    LOAD_VAL("STEERING", "WSoftLock", Steering.Wheel.SoftLock);
+    LOAD_VAL("STEERING", "WSteeringMult", Steering.Wheel.SteeringMult);
 
     // [CAM]
-    Misc.Camera.Enable = ini.GetBoolValue("CAM", "Enable", gSettings.Misc.Camera.Enable);
-    Misc.Camera.AttachId = ini.GetLongValue("CAM", "AttachId", gSettings.Misc.Camera.AttachId);
+    LOAD_VAL("CAM", "Enable", Misc.Camera.Enable);
+    LOAD_VAL("CAM", "AttachId", Misc.Camera.AttachId);
 
-    Misc.Camera.Movement.Follow = ini.GetBoolValue("CAM", "FollowMovement", gSettings.Misc.Camera.Movement.Follow);
-    Misc.Camera.Movement.RotationDirectionMult = ini.GetDoubleValue("CAM", "MovementMultVel", gSettings.Misc.Camera.Movement.RotationDirectionMult);
-    Misc.Camera.Movement.RotationRotationMult = ini.GetDoubleValue("CAM", "MovementMultRot", gSettings.Misc.Camera.Movement.RotationRotationMult);
-    Misc.Camera.Movement.RotationMaxAngle = ini.GetDoubleValue("CAM", "MovementCap", gSettings.Misc.Camera.Movement.RotationMaxAngle);
+    LOAD_VAL("CAM", "FollowMovement", Misc.Camera.Movement.Follow);
+    LOAD_VAL("CAM", "MovementMultVel", Misc.Camera.Movement.RotationDirectionMult);
+    LOAD_VAL("CAM", "MovementMultRot", Misc.Camera.Movement.RotationRotationMult);
+    LOAD_VAL("CAM", "MovementCap", Misc.Camera.Movement.RotationMaxAngle);
 
-    Misc.Camera.Movement.LongForwardMult = ini.GetDoubleValue("CAM", "LongForwardMult", gSettings.Misc.Camera.Movement.LongForwardMult);
-    Misc.Camera.Movement.LongBackwardMult = ini.GetDoubleValue("CAM", "LongBackwardMult", gSettings.Misc.Camera.Movement.LongBackwardMult);
-    Misc.Camera.Movement.LongDeadzone = ini.GetDoubleValue("CAM", "LongDeadzone", gSettings.Misc.Camera.Movement.LongDeadzone);
-    Misc.Camera.Movement.LongGamma = ini.GetDoubleValue("CAM", "LongGamma", gSettings.Misc.Camera.Movement.LongGamma);
-    Misc.Camera.Movement.LongForwardLimit = ini.GetDoubleValue("CAM", "LongForwardLimit", gSettings.Misc.Camera.Movement.LongForwardLimit);
-    Misc.Camera.Movement.LongBackwardLimit = ini.GetDoubleValue("CAM", "LongBackwardLimit", gSettings.Misc.Camera.Movement.LongBackwardLimit);
+    LOAD_VAL("CAM", "LongForwardMult", Misc.Camera.Movement.LongForwardMult);
+    LOAD_VAL("CAM", "LongBackwardMult", Misc.Camera.Movement.LongBackwardMult);
+    LOAD_VAL("CAM", "LongDeadzone", Misc.Camera.Movement.LongDeadzone);
+    LOAD_VAL("CAM", "LongGamma", Misc.Camera.Movement.LongGamma);
+    LOAD_VAL("CAM", "LongForwardLimit", Misc.Camera.Movement.LongForwardLimit);
+    LOAD_VAL("CAM", "LongBackwardLimit", Misc.Camera.Movement.LongBackwardLimit);
 
-    Misc.Camera.RemoveHead = ini.GetBoolValue("CAM", "RemoveHead", gSettings.Misc.Camera.RemoveHead);
-    Misc.Camera.FOV = ini.GetDoubleValue("CAM", "FOV", gSettings.Misc.Camera.FOV);
-    Misc.Camera.OffsetHeight = ini.GetDoubleValue("CAM", "OffsetHeight", gSettings.Misc.Camera.OffsetHeight);
-    Misc.Camera.OffsetForward = ini.GetDoubleValue("CAM", "OffsetForward", gSettings.Misc.Camera.OffsetForward);
-    Misc.Camera.OffsetSide = ini.GetDoubleValue("CAM", "OffsetSide", gSettings.Misc.Camera.OffsetSide);
-    Misc.Camera.Pitch = ini.GetDoubleValue("CAM", "Pitch", gSettings.Misc.Camera.Pitch);
-    Misc.Camera.LookTime = ini.GetDoubleValue("CAM", "LookTime", gSettings.Misc.Camera.LookTime);
-    Misc.Camera.MouseLookTime = ini.GetDoubleValue("CAM", "MouseLookTime", gSettings.Misc.Camera.MouseLookTime);
-    Misc.Camera.MouseCenterTimeout = ini.GetLongValue("CAM", "MouseCenterTimeout", gSettings.Misc.Camera.MouseCenterTimeout);
-    Misc.Camera.MouseSensitivity = ini.GetDoubleValue("CAM", "MouseSensitivity", gSettings.Misc.Camera.MouseSensitivity);
+    LOAD_VAL("CAM", "RemoveHead", Misc.Camera.RemoveHead);
+    LOAD_VAL("CAM", "FOV", Misc.Camera.FOV);
+    LOAD_VAL("CAM", "OffsetHeight", Misc.Camera.OffsetHeight);
+    LOAD_VAL("CAM", "OffsetForward", Misc.Camera.OffsetForward);
+    LOAD_VAL("CAM", "OffsetSide", Misc.Camera.OffsetSide);
+    LOAD_VAL("CAM", "Pitch", Misc.Camera.Pitch);
+    LOAD_VAL("CAM", "LookTime", Misc.Camera.LookTime);
+    LOAD_VAL("CAM", "MouseLookTime", Misc.Camera.MouseLookTime);
+    LOAD_VAL("CAM", "MouseCenterTimeout", Misc.Camera.MouseCenterTimeout);
+    LOAD_VAL("CAM", "MouseSensitivity", Misc.Camera.MouseSensitivity);
 
-    Misc.Camera.Bike.Disable = ini.GetBoolValue("CAM", "BikeDisable", gSettings.Misc.Camera.Bike.Disable);
-    Misc.Camera.Bike.AttachId = ini.GetLongValue("CAM", "BikeAttachId", gSettings.Misc.Camera.Bike.AttachId);
-    Misc.Camera.Bike.FOV = ini.GetDoubleValue("CAM", "BikeFOV", gSettings.Misc.Camera.Bike.FOV);
-    Misc.Camera.Bike.OffsetHeight = ini.GetDoubleValue("CAM", "BikeOffsetHeight", gSettings.Misc.Camera.Bike.OffsetHeight);
-    Misc.Camera.Bike.OffsetForward = ini.GetDoubleValue("CAM", "BikeOffsetForward", gSettings.Misc.Camera.Bike.OffsetForward);
-    Misc.Camera.Bike.OffsetSide = ini.GetDoubleValue("CAM", "BikeOffsetSide", gSettings.Misc.Camera.Bike.OffsetSide);
-    Misc.Camera.Bike.Pitch = ini.GetDoubleValue("CAM", "BikePitch", gSettings.Misc.Camera.Bike.Pitch);
+    LOAD_VAL("CAM", "BikeDisable", Misc.Camera.Bike.Disable);
+    LOAD_VAL("CAM", "BikeAttachId", Misc.Camera.Bike.AttachId);
+    LOAD_VAL("CAM", "BikeFOV", Misc.Camera.Bike.FOV);
+    LOAD_VAL("CAM", "BikeOffsetHeight", Misc.Camera.Bike.OffsetHeight);
+    LOAD_VAL("CAM", "BikeOffsetForward", Misc.Camera.Bike.OffsetForward);
+    LOAD_VAL("CAM", "BikeOffsetSide", Misc.Camera.Bike.OffsetSide);
+    LOAD_VAL("CAM", "BikePitch", Misc.Camera.Bike.Pitch);
 }
 
 void VehicleConfig::SaveSettings() {
@@ -248,121 +267,118 @@ void VehicleConfig::saveGeneral() {
     ini.SetValue("ID", "Description", Description.c_str());
 
     // [MT_OPTIONS]
-    if (MTOptions.ShiftMode != mBaseConfig->MTOptions.ShiftMode) {
-        SetValue(ini, "MT_OPTIONS", "ShiftMode", static_cast<int>(MTOptions.ShiftMode));
-    }
-
-    SET_VALUE("MT_OPTIONS", "ClutchCatching", MTOptions.ClutchCreep);
-    SET_VALUE("MT_OPTIONS", "ClutchShiftingH", MTOptions.ClutchShiftH);
-    SET_VALUE("MT_OPTIONS", "ClutchShiftingS", MTOptions.ClutchShiftS);
+    SAVE_VAL("MT_OPTIONS", "ShiftMode", MTOptions.ShiftMode);
+    SAVE_VAL("MT_OPTIONS", "ClutchCatching", MTOptions.ClutchCreep);
+    SAVE_VAL("MT_OPTIONS", "ClutchShiftingH", MTOptions.ClutchShiftH);
+    SAVE_VAL("MT_OPTIONS", "ClutchShiftingS", MTOptions.ClutchShiftS);
 
     // [MT_PARAMS]
-    SET_VALUE("MT_PARAMS", "ClutchCatchpoint", MTParams.ClutchThreshold);
-    SET_VALUE("MT_PARAMS", "StallingRPM", MTParams.StallingRPM);
-    SET_VALUE("MT_PARAMS", "StallingRate", MTParams.StallingRate);
-    SET_VALUE("MT_PARAMS", "StallingSlip", MTParams.StallingSlip);
-    SET_VALUE("MT_PARAMS", "RPMDamage", MTParams.RPMDamage);
-    SET_VALUE("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
-    SET_VALUE("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);
-    SET_VALUE("MT_PARAMS", "EngBrakeThreshold", MTParams.EngBrakeThreshold);
-    SET_VALUE("MT_PARAMS", "CreepIdleThrottle", MTParams.CreepIdleThrottle);
-    SET_VALUE("MT_PARAMS", "CreepIdleRPM", MTParams.CreepIdleRPM);
+    SAVE_VAL("MT_PARAMS", "ClutchCatchpoint", MTParams.ClutchThreshold);
+    SAVE_VAL("MT_PARAMS", "StallingRPM", MTParams.StallingRPM);
+    SAVE_VAL("MT_PARAMS", "StallingRate", MTParams.StallingRate);
+    SAVE_VAL("MT_PARAMS", "StallingSlip", MTParams.StallingSlip);
+    SAVE_VAL("MT_PARAMS", "RPMDamage", MTParams.RPMDamage);
+    SAVE_VAL("MT_PARAMS", "MisshiftDamage", MTParams.MisshiftDamage);
+    SAVE_VAL("MT_PARAMS", "EngBrakePower", MTParams.EngBrakePower);
+    SAVE_VAL("MT_PARAMS", "EngBrakeThreshold", MTParams.EngBrakeThreshold);
+    SAVE_VAL("MT_PARAMS", "CreepIdleThrottle", MTParams.CreepIdleThrottle);
+    SAVE_VAL("MT_PARAMS", "CreepIdleRPM", MTParams.CreepIdleRPM);
 
     // [DRIVING_ASSISTS]
-    SET_VALUE("DRIVING_ASSISTS", "ABS", DriveAssists.ABS.Enable);
-    SET_VALUE("DRIVING_ASSISTS", "ABSFilter", DriveAssists.ABS.Filter);
-    SET_VALUE("DRIVING_ASSISTS", "TCS", DriveAssists.TCS.Enable);
-    SET_VALUE("DRIVING_ASSISTS", "TCSMode", DriveAssists.TCS.Mode);
-    SET_VALUE("DRIVING_ASSISTS", "TCSSlipMax", DriveAssists.TCS.SlipMax);
-    SET_VALUE("DRIVING_ASSISTS", "ESP", DriveAssists.ESP.Enable);
-    SET_VALUE("DRIVING_ASSISTS", "ESPOverMin", DriveAssists.ESP.OverMin);
-    SET_VALUE("DRIVING_ASSISTS", "ESPOverMax", DriveAssists.ESP.OverMax);
-    SET_VALUE("DRIVING_ASSISTS", "ESPOverMinComp", DriveAssists.ESP.OverMinComp);
-    SET_VALUE("DRIVING_ASSISTS", "ESPOverMaxComp", DriveAssists.ESP.OverMaxComp);
-    SET_VALUE("DRIVING_ASSISTS", "ESPUnderMin", DriveAssists.ESP.UnderMin);
-    SET_VALUE("DRIVING_ASSISTS", "ESPUnderMax", DriveAssists.ESP.UnderMax);
-    SET_VALUE("DRIVING_ASSISTS", "ESPUnderMinComp", DriveAssists.ESP.UnderMinComp);
-    SET_VALUE("DRIVING_ASSISTS", "ESPUnderMaxComp", DriveAssists.ESP.UnderMaxComp);
+    SAVE_VAL("DRIVING_ASSISTS", "ABS", DriveAssists.ABS.Enable);
+    SAVE_VAL("DRIVING_ASSISTS", "ABSFilter", DriveAssists.ABS.Filter);
+    SAVE_VAL("DRIVING_ASSISTS", "TCS", DriveAssists.TCS.Enable);
+    SAVE_VAL("DRIVING_ASSISTS", "TCSMode", DriveAssists.TCS.Mode);
+    SAVE_VAL("DRIVING_ASSISTS", "TCSSlipMax", DriveAssists.TCS.SlipMax);
+    SAVE_VAL("DRIVING_ASSISTS", "ESP", DriveAssists.ESP.Enable);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPOverMin", DriveAssists.ESP.OverMin);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPOverMax", DriveAssists.ESP.OverMax);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPOverMinComp", DriveAssists.ESP.OverMinComp);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPOverMaxComp", DriveAssists.ESP.OverMaxComp);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPUnderMin", DriveAssists.ESP.UnderMin);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPUnderMax", DriveAssists.ESP.UnderMax);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPUnderMinComp", DriveAssists.ESP.UnderMinComp);
+    SAVE_VAL("DRIVING_ASSISTS", "ESPUnderMaxComp", DriveAssists.ESP.UnderMaxComp);
 
-    SET_VALUE("DRIVING_ASSISTS", "LSD", DriveAssists.LSD.Enable);
-    SET_VALUE("DRIVING_ASSISTS", "LSDViscosity", DriveAssists.LSD.Viscosity);
+    SAVE_VAL("DRIVING_ASSISTS", "LSD", DriveAssists.LSD.Enable);
+    SAVE_VAL("DRIVING_ASSISTS", "LSDViscosity", DriveAssists.LSD.Viscosity);
 
-    SET_VALUE("DRIVING_ASSISTS", "AWD", DriveAssists.AWD.Enable);
-    SET_VALUE("DRIVING_ASSISTS", "AWDBiasAtMaxTransfer", DriveAssists.AWD.BiasAtMaxTransfer);
-    SET_VALUE("DRIVING_ASSISTS", "AWDUseCustomBaseBias", DriveAssists.AWD.UseCustomBaseBias);
-    SET_VALUE("DRIVING_ASSISTS", "AWDCustomBaseBias", DriveAssists.AWD.CustomBaseBias);
-    SET_VALUE("DRIVING_ASSISTS", "AWDCustomMin", DriveAssists.AWD.CustomMin);
-    SET_VALUE("DRIVING_ASSISTS", "AWDCustomMax", DriveAssists.AWD.CustomMax);
-    SET_VALUE("DRIVING_ASSISTS", "AWDUseTraction", DriveAssists.AWD.UseTraction);
-    SET_VALUE("DRIVING_ASSISTS", "AWDTractionLossMin", DriveAssists.AWD.TractionLossMin);
-    SET_VALUE("DRIVING_ASSISTS", "AWDTractionLossMax", DriveAssists.AWD.TractionLossMax);
-    SET_VALUE("DRIVING_ASSISTS", "AWDUseOversteer", DriveAssists.AWD.UseOversteer);
-    SET_VALUE("DRIVING_ASSISTS", "AWDOversteerMin", DriveAssists.AWD.OversteerMin);
-    SET_VALUE("DRIVING_ASSISTS", "AWDOversteerMax", DriveAssists.AWD.OversteerMax);
-    SET_VALUE("DRIVING_ASSISTS", "AWDUseUndersteer", DriveAssists.AWD.UseUndersteer);
-    SET_VALUE("DRIVING_ASSISTS", "AWDUndersteerMin", DriveAssists.AWD.UndersteerMin);
-    SET_VALUE("DRIVING_ASSISTS", "AWDUndersteerMax", DriveAssists.AWD.UndersteerMax);
+    SAVE_VAL("DRIVING_ASSISTS", "AWD", DriveAssists.AWD.Enable);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDBiasAtMaxTransfer", DriveAssists.AWD.BiasAtMaxTransfer);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDUseCustomBaseBias", DriveAssists.AWD.UseCustomBaseBias);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDCustomBaseBias", DriveAssists.AWD.CustomBaseBias);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDCustomMin", DriveAssists.AWD.CustomMin);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDCustomMax", DriveAssists.AWD.CustomMax);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDUseTraction", DriveAssists.AWD.UseTraction);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDTractionLossMin", DriveAssists.AWD.TractionLossMin);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDTractionLossMax", DriveAssists.AWD.TractionLossMax);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDUseOversteer", DriveAssists.AWD.UseOversteer);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDOversteerMin", DriveAssists.AWD.OversteerMin);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDOversteerMax", DriveAssists.AWD.OversteerMax);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDUseUndersteer", DriveAssists.AWD.UseUndersteer);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDUndersteerMin", DriveAssists.AWD.UndersteerMin);
+    SAVE_VAL("DRIVING_ASSISTS", "AWDUndersteerMax", DriveAssists.AWD.UndersteerMax);
 
-    if (DriveAssists.AWD.SpecialFlags != mBaseConfig->DriveAssists.AWD.SpecialFlags)
+    if (mBaseConfig == this || DriveAssists.AWD.SpecialFlags != mBaseConfig->DriveAssists.AWD.SpecialFlags || DriveAssists.AWD.SpecialFlags.Changed())
         ini.SetLongValue("DRIVING_ASSISTS", "AWDSpecialFlags", DriveAssists.AWD.SpecialFlags, nullptr, true);
 
     //[STEERING_OVERRIDE]
-    SET_VALUE("STEERING", "CSUseCustomLock", Steering.CustomSteering.UseCustomLock);
-    SET_VALUE("STEERING", "CSSoftLock", Steering.CustomSteering.SoftLock);
-    SET_VALUE("STEERING", "CSSteeringMult", Steering.CustomSteering.SteeringMult);
+    SAVE_VAL("STEERING", "CSUseCustomLock", Steering.CustomSteering.UseCustomLock);
+    SAVE_VAL("STEERING", "CSSoftLock", Steering.CustomSteering.SoftLock);
+    SAVE_VAL("STEERING", "CSSteeringMult", Steering.CustomSteering.SteeringMult);
 
-    SET_VALUE("STEERING", "WSoftLock", Steering.Wheel.SoftLock);
-    SET_VALUE("STEERING", "WSteeringMult", Steering.Wheel.SteeringMult);
+    SAVE_VAL("STEERING", "WSoftLock", Steering.Wheel.SoftLock);
+    SAVE_VAL("STEERING", "WSteeringMult", Steering.Wheel.SteeringMult);
 
     // [SHIFT_OPTIONS]
-    SET_VALUE("SHIFT_OPTIONS", "UpshiftCut", ShiftOptions.UpshiftCut);
-    SET_VALUE("SHIFT_OPTIONS", "DownshiftBlip", ShiftOptions.DownshiftBlip);
-    SET_VALUE("SHIFT_OPTIONS", "ClutchRateMult", ShiftOptions.ClutchRateMult);
-    SET_VALUE("SHIFT_OPTIONS", "RPMTolerance", ShiftOptions.RPMTolerance);
+    SAVE_VAL("SHIFT_OPTIONS", "UpshiftCut", ShiftOptions.UpshiftCut);
+    SAVE_VAL("SHIFT_OPTIONS", "DownshiftBlip", ShiftOptions.DownshiftBlip);
+    SAVE_VAL("SHIFT_OPTIONS", "ClutchRateMult", ShiftOptions.ClutchRateMult);
+    SAVE_VAL("SHIFT_OPTIONS", "RPMTolerance", ShiftOptions.RPMTolerance);
 
     // [AUTO_PARAMS]
-    SET_VALUE("AUTO_PARAMS", "UpshiftLoad", AutoParams.UpshiftLoad);
-    SET_VALUE("AUTO_PARAMS", "DownshiftLoad", AutoParams.DownshiftLoad);
-    SET_VALUE("AUTO_PARAMS", "NextGearMinRPM", AutoParams.NextGearMinRPM);
-    SET_VALUE("AUTO_PARAMS", "CurrGearMinRPM", AutoParams.CurrGearMinRPM);
-    SET_VALUE("AUTO_PARAMS", "EcoRate", AutoParams.EcoRate);
-    SET_VALUE("AUTO_PARAMS", "DownshiftTimeoutMult", AutoParams.DownshiftTimeoutMult);
-    SET_VALUE("AUTO_PARAMS", "UsingATCU", AutoParams.UsingATCU);
+    SAVE_VAL("AUTO_PARAMS", "UpshiftLoad", AutoParams.UpshiftLoad);
+    SAVE_VAL("AUTO_PARAMS", "DownshiftLoad", AutoParams.DownshiftLoad);
+    SAVE_VAL("AUTO_PARAMS", "NextGearMinRPM", AutoParams.NextGearMinRPM);
+    SAVE_VAL("AUTO_PARAMS", "CurrGearMinRPM", AutoParams.CurrGearMinRPM);
+    SAVE_VAL("AUTO_PARAMS", "EcoRate", AutoParams.EcoRate);
+    SAVE_VAL("AUTO_PARAMS", "DownshiftTimeoutMult", AutoParams.DownshiftTimeoutMult);
+    SAVE_VAL("AUTO_PARAMS", "UsingATCU", AutoParams.UsingATCU);
 
     // [CAM]
-    SET_VALUE("CAM", "Enable", Misc.Camera.Enable);
-    SET_VALUE("CAM", "AttachId", Misc.Camera.AttachId);
+    SAVE_VAL("CAM", "Enable", Misc.Camera.Enable);
+    SAVE_VAL("CAM", "AttachId", Misc.Camera.AttachId);
 
-    SET_VALUE("CAM", "FollowMovement", Misc.Camera.Movement.Follow);
-    SET_VALUE("CAM", "MovementMultVel", Misc.Camera.Movement.RotationDirectionMult);
-    SET_VALUE("CAM", "MovementMultRot", Misc.Camera.Movement.RotationRotationMult);
-    SET_VALUE("CAM", "MovementCap", Misc.Camera.Movement.RotationMaxAngle);
+    SAVE_VAL("CAM", "FollowMovement", Misc.Camera.Movement.Follow);
+    SAVE_VAL("CAM", "MovementMultVel", Misc.Camera.Movement.RotationDirectionMult);
+    SAVE_VAL("CAM", "MovementMultRot", Misc.Camera.Movement.RotationRotationMult);
+    SAVE_VAL("CAM", "MovementCap", Misc.Camera.Movement.RotationMaxAngle);
 
-    SET_VALUE("CAM", "LongForwardMult", Misc.Camera.Movement.LongForwardMult);
-    SET_VALUE("CAM", "LongBackwardMult", Misc.Camera.Movement.LongBackwardMult);
-    SET_VALUE("CAM", "LongDeadzone", Misc.Camera.Movement.LongDeadzone);
-    SET_VALUE("CAM", "LongGamma", Misc.Camera.Movement.LongGamma);
-    SET_VALUE("CAM", "LongForwardLimit", Misc.Camera.Movement.LongForwardLimit);
-    SET_VALUE("CAM", "LongBackwardLimit", Misc.Camera.Movement.LongBackwardLimit);
+    SAVE_VAL("CAM", "LongForwardMult", Misc.Camera.Movement.LongForwardMult);
+    SAVE_VAL("CAM", "LongBackwardMult", Misc.Camera.Movement.LongBackwardMult);
+    SAVE_VAL("CAM", "LongDeadzone", Misc.Camera.Movement.LongDeadzone);
+    SAVE_VAL("CAM", "LongGamma", Misc.Camera.Movement.LongGamma);
+    SAVE_VAL("CAM", "LongForwardLimit", Misc.Camera.Movement.LongForwardLimit);
+    SAVE_VAL("CAM", "LongBackwardLimit", Misc.Camera.Movement.LongBackwardLimit);
 
-    SET_VALUE("CAM", "RemoveHead", Misc.Camera.RemoveHead);
-    SET_VALUE("CAM", "FOV", Misc.Camera.FOV);
-    SET_VALUE("CAM", "OffsetHeight", Misc.Camera.OffsetHeight);
-    SET_VALUE("CAM", "OffsetForward", Misc.Camera.OffsetForward);
-    SET_VALUE("CAM", "OffsetSide", Misc.Camera.OffsetSide);
-    SET_VALUE("CAM", "Pitch", Misc.Camera.Pitch);
-    SET_VALUE("CAM", "LookTime", Misc.Camera.LookTime);
-    SET_VALUE("CAM", "MouseLookTime", Misc.Camera.MouseLookTime);
-    SET_VALUE("CAM", "MouseCenterTimeout", Misc.Camera.MouseCenterTimeout);
-    SET_VALUE("CAM", "MouseSensitivity", Misc.Camera.MouseSensitivity);
+    SAVE_VAL("CAM", "RemoveHead", Misc.Camera.RemoveHead);
+    SAVE_VAL("CAM", "FOV", Misc.Camera.FOV);
+    SAVE_VAL("CAM", "OffsetHeight", Misc.Camera.OffsetHeight);
+    SAVE_VAL("CAM", "OffsetForward", Misc.Camera.OffsetForward);
+    SAVE_VAL("CAM", "OffsetSide", Misc.Camera.OffsetSide);
+    SAVE_VAL("CAM", "Pitch", Misc.Camera.Pitch);
+    SAVE_VAL("CAM", "LookTime", Misc.Camera.LookTime);
+    SAVE_VAL("CAM", "MouseLookTime", Misc.Camera.MouseLookTime);
+    SAVE_VAL("CAM", "MouseCenterTimeout", Misc.Camera.MouseCenterTimeout);
+    SAVE_VAL("CAM", "MouseSensitivity", Misc.Camera.MouseSensitivity);
 
-    SET_VALUE("CAM", "BikeDisable", Misc.Camera.Bike.Disable);
-    SET_VALUE("CAM", "BikeAttachId", Misc.Camera.Bike.AttachId);
-    SET_VALUE("CAM", "BikeFOV", Misc.Camera.Bike.FOV);
-    SET_VALUE("CAM", "BikeOffsetHeight", Misc.Camera.Bike.OffsetHeight);
-    SET_VALUE("CAM", "BikeOffsetForward", Misc.Camera.Bike.OffsetForward);
-    SET_VALUE("CAM", "BikeOffsetSide", Misc.Camera.Bike.OffsetSide);
-    SET_VALUE("CAM", "BikePitch", Misc.Camera.Bike.Pitch);
+    SAVE_VAL("CAM", "BikeDisable", Misc.Camera.Bike.Disable);
+    SAVE_VAL("CAM", "BikeAttachId", Misc.Camera.Bike.AttachId);
+    SAVE_VAL("CAM", "BikeFOV", Misc.Camera.Bike.FOV);
+    SAVE_VAL("CAM", "BikeOffsetHeight", Misc.Camera.Bike.OffsetHeight);
+    SAVE_VAL("CAM", "BikeOffsetForward", Misc.Camera.Bike.OffsetForward);
+    SAVE_VAL("CAM", "BikeOffsetSide", Misc.Camera.Bike.OffsetSide);
+    SAVE_VAL("CAM", "BikePitch", Misc.Camera.Bike.Pitch);
 
     result = ini.SaveFile(mFile.c_str());
     CHECK_LOG_SI_ERROR(result, "save");

--- a/Gears/VehicleConfig.h
+++ b/Gears/VehicleConfig.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <string>
+#include <vector>
 
-enum class EShiftMode : int {
+enum EShiftMode : int {
     Sequential = 0,
     HPattern = 1,
     Automatic = 2,
@@ -8,8 +10,23 @@ enum class EShiftMode : int {
 
 EShiftMode Next(EShiftMode mode);
 
-#include <string>
-#include <vector>
+template <typename T>
+class Tracked {
+    T mValue;
+    bool mChanged = false;
+public:
+    Tracked(T val) : mValue(val), mChanged(false) { }
+    Tracked& operator=(T v) { mChanged = true; mValue = v; return *this; }
+ 
+    operator T() const { return mValue; }
+    operator T&() { return mValue; }
+
+    bool operator==(const T& rhs) { return mValue == rhs; }
+    bool operator!=(const T& rhs) { return !(mValue == rhs); }
+
+    bool Changed() const { return mChanged; }
+    void Set(T val) { mValue = val;  mChanged = false; }
+};
 
 class VehicleConfig {
 public:
@@ -30,64 +47,63 @@ public:
 
     // [MT_OPTIONS]
     struct {
-        EShiftMode ShiftMode = EShiftMode::Sequential;
-
-        bool ClutchCreep = false;
-        bool ClutchShiftH = true;
-        bool ClutchShiftS = false;
+        Tracked<EShiftMode> ShiftMode = EShiftMode::Sequential;
+        Tracked<bool> ClutchCreep = false;
+        Tracked<bool> ClutchShiftH = true;
+        Tracked<bool> ClutchShiftS = false;
     } MTOptions;
 
     // [MT_PARAMS]
     struct {
-        float EngBrakePower = 0.0f;
-        float EngBrakeThreshold = 0.75f;
+        Tracked<float> EngBrakePower = 0.0f;
+        Tracked<float> EngBrakeThreshold = 0.75f;
         // Clutch _lift_ distance
-        float ClutchThreshold = 0.15f;
-        float StallingRPM = 0.09f;
-        float StallingRate = 3.75f;
-        float StallingSlip = 0.40f;
-        float RPMDamage = 0.1f;
-        float MisshiftDamage = 5.0f;
-        float CreepIdleThrottle = 0.1f;
-        float CreepIdleRPM = 0.1f;
+        Tracked<float> ClutchThreshold = 0.15f;
+        Tracked<float> StallingRPM = 0.09f;
+        Tracked<float> StallingRate = 3.75f;
+        Tracked<float> StallingSlip = 0.40f;
+        Tracked<float> RPMDamage = 0.1f;
+        Tracked<float> MisshiftDamage = 5.0f;
+        Tracked<float> CreepIdleThrottle = 0.1f;
+        Tracked<float> CreepIdleRPM = 0.1f;
     } MTParams;
 
     // [DRIVING_ASSISTS]
     struct {
         struct {
-            bool Enable = false;
+            Tracked<bool> Enable = false;
             // true: only applied to abs-less vehicles
-            bool Filter = true;
+            Tracked<bool> Filter = true;
         } ABS;
 
         struct {
-            bool Enable = false;
+            Tracked<bool> Enable = false;
             // 0 Brake, 1 Throttle 
-            int Mode = 0;
+            Tracked<int> Mode = 0;
             // tyre speed threshold, m/s
-            float SlipMax = 2.5f;
+            Tracked<float> SlipMax = 2.5f;
         } TCS;
 
         struct {
-            bool Enable = false;
+            Tracked<bool> Enable = false;
 
-            float OverMin = 05.0f; // deg
-            float OverMax = 15.0f; // deg
+            Tracked<float> OverMin = 05.0f; // deg
+            Tracked<float> OverMax = 15.0f; // deg
 
-            float OverMinComp = 0.0f; // brake mult
-            float OverMaxComp = 2.0f; // brake mult
+            Tracked<float> OverMinComp = 0.0f; // brake mult
+            Tracked<float> OverMaxComp = 2.0f; // brake mult
 
-            float UnderMin = 5.0f; // deg
-            float UnderMax = 10.0f; // deg
+            Tracked<float> UnderMin = 5.0f; // deg
+            Tracked<float> UnderMax = 10.0f; // deg
 
-            float UnderMinComp = 0.0f; // brake mult
-            float UnderMaxComp = 1.0f; // brake mult
+            Tracked<float> UnderMinComp = 0.0f; // brake mult
+            Tracked<float> UnderMaxComp = 1.0f; // brake mult
 
         } ESP;
 
         struct {
-            bool Enable = false;
-            float Viscosity = 1.0f;
+            Tracked<bool> Enable = false;
+            Tracked<float> Viscosity = 1.0f;
         } LSD;
 
         struct {
@@ -95,74 +111,74 @@ public:
             // fDriveBiasFront >= 0.1 &&
             // fDriveBiasFront <= 0.9 &&
             // fDriveBiasFront != 0.5
-            bool Enable = false;
+            Tracked<bool> Enable = false;
 
             // Bias when bias transfer is maximized
-            float BiasAtMaxTransfer = 0.5f;
+            Tracked<float> BiasAtMaxTransfer = 0.5f;
 
             // AWD::EAWDMode Mode = AWD::EAWDMode::Automatic;
 
-            bool UseCustomBaseBias = false;
-            float CustomBaseBias = 0.01f;
-            float CustomMin = 0.0f;
-            float CustomMax = 1.0f;
+            Tracked<bool> UseCustomBaseBias = false;
+            Tracked<float> CustomBaseBias = 0.01f;
+            Tracked<float> CustomMin = 0.0f;
+            Tracked<float> CustomMax = 1.0f;
 
-            bool UseTraction = false;
-            float TractionLossMin = 1.05f; // "Strong" axle is  5% faster than "weak" axle 
-            float TractionLossMax = 1.50f; // "Strong" axle is 50% faster than "weak" axle
+            Tracked<bool> UseTraction = false;
+            Tracked<float> TractionLossMin = 1.05f; // "Strong" axle is  5% faster than "weak" axle 
+            Tracked<float> TractionLossMax = 1.50f; // "Strong" axle is 50% faster than "weak" axle
 
             // Should only be used for RWD-biased cars
-            bool UseOversteer = false;
-            float OversteerMin = 5.0f; // degrees
-            float OversteerMax = 15.0f; // degrees
+            Tracked<bool> UseOversteer = false;
+            Tracked<float> OversteerMin = 5.0f; // degrees
+            Tracked<float> OversteerMax = 15.0f; // degrees
 
             // Should only be used for FWD-biased cars
-            bool UseUndersteer = false;
-            float UndersteerMin = 5.0f; // degrees
-            float UndersteerMax = 15.0f; // degrees
+            Tracked<bool> UseUndersteer = false;
+            Tracked<float> UndersteerMin = 5.0f; // degrees
+            Tracked<float> UndersteerMax = 15.0f; // degrees
 
             // See AWD.h for currently supported flags
-            uint32_t SpecialFlags = 0;
+            Tracked<uint32_t> SpecialFlags = 0;
         } AWD;
     } DriveAssists;
 
     // [SHIFT_OPTIONS]
     struct {
-        bool UpshiftCut = true;
-        bool DownshiftBlip = true;
-        float ClutchRateMult = 1.0f;
-        float RPMTolerance = 0.2f;
+        Tracked<bool> UpshiftCut = true;
+        Tracked<bool> DownshiftBlip = true;
+        Tracked<float> ClutchRateMult = 1.0f;
+        Tracked<float> RPMTolerance = 0.2f;
     } ShiftOptions;
 
     // [AUTO_PARAMS]
     struct {
         // Lower = upshift later
-        float UpshiftLoad = 0.12f;
+        Tracked<float> UpshiftLoad = 0.12f;
         // Higher = downshift later
-        float DownshiftLoad = 0.60f;
+        Tracked<float> DownshiftLoad = 0.60f;
         // Don't upshift until next gears' RPM is over this value.
-        float NextGearMinRPM = 0.33f;
+        Tracked<float> NextGearMinRPM = 0.33f;
         // Downshift when RPM drops below this value.
-        float CurrGearMinRPM = 0.27f;
+        Tracked<float> CurrGearMinRPM = 0.27f;
         // Lower = keep in low gear longer // eco - 0.33
-        float EcoRate = 0.05f;
+        Tracked<float> EcoRate = 0.05f;
         // Timeout mult for not downshifting after an upshift
-        float DownshiftTimeoutMult = 1.0f;
+        Tracked<float> DownshiftTimeoutMult = 1.0f;
         // Experimental new tcu
-        bool UsingATCU = false;
+        Tracked<bool> UsingATCU = false;
     } AutoParams;
 
     // [STEERING]
     struct {
         struct {
-            bool UseCustomLock = true;
-            float SoftLock = 720.0f;
-            float SteeringMult = 1.0f;
+            Tracked<bool> UseCustomLock = true;
+            Tracked<float> SoftLock = 720.0f;
+            Tracked<float> SteeringMult = 1.0f;
         } CustomSteering;
 
         struct {
-            float SoftLock = 720.0f;
-            float SteeringMult = 1.0f;
+            Tracked<float> SoftLock = 720.0f;
+            Tracked<float> SteeringMult = 1.0f;
         } Wheel;
     } Steering;
 
@@ -170,41 +186,41 @@ public:
     struct {
         // [CAM]
         struct {
-            bool Enable = true;
-            int AttachId = 0; // 0: Head, 1: Vehicle, 2: FPV Offset?
-            bool RemoveHead = true;
+            Tracked<bool> Enable = true;
+            Tracked<int> AttachId = 0; // 0: Head, 1: Vehicle, 2: FPV Offset?
+            Tracked<bool> RemoveHead = true;
 
             struct {
-                bool Follow = true;
-                float RotationDirectionMult = 0.750f;
-                float RotationRotationMult = 0.15f;
-                float RotationMaxAngle = 45.0f;
+                Tracked<bool> Follow = true;
+                Tracked<float> RotationDirectionMult = 0.750f;
+                Tracked<float> RotationRotationMult = 0.15f;
+                Tracked<float> RotationMaxAngle = 45.0f;
 
-                float LongForwardMult = 0.05f;
-                float LongBackwardMult = 0.10f;
-                float LongDeadzone = 0.95f;
-                float LongGamma = 1.0f;
-                float LongForwardLimit = 0.10f;
-                float LongBackwardLimit = 0.12f;
+                Tracked<float> LongForwardMult = 0.05f;
+                Tracked<float> LongBackwardMult = 0.10f;
+                Tracked<float> LongDeadzone = 0.95f;
+                Tracked<float> LongGamma = 1.0f;
+                Tracked<float> LongForwardLimit = 0.10f;
+                Tracked<float> LongBackwardLimit = 0.12f;
             } Movement;
 
-            float FOV = 55.0f;
-            float OffsetHeight = 0.04f;
-            float OffsetForward = 0.05f;
-            float OffsetSide = 0.0f;
-            float Pitch = 0.0f;
-            float LookTime = 0.000010f;
-            float MouseLookTime = 0.000001f;
-            int MouseCenterTimeout = 750;
-            float MouseSensitivity = 0.3f;
+            Tracked<float> FOV = 55.0f;
+            Tracked<float> OffsetHeight = 0.04f;
+            Tracked<float> OffsetForward = 0.05f;
+            Tracked<float> OffsetSide = 0.0f;
+            Tracked<float> Pitch = 0.0f;
+            Tracked<float> LookTime = 0.000010f;
+            Tracked<float> MouseLookTime = 0.000001f;
+            Tracked<int> MouseCenterTimeout = 750;
+            Tracked<float> MouseSensitivity = 0.3f;
             struct {
-                bool Disable = false;
-                int AttachId = 0; // 0: Head, 1: Vehicle, 2: FPV Offset?
-                float FOV = 55.0f;
-                float OffsetHeight = -0.05f;
-                float OffsetForward = -0.08f;
-                float OffsetSide = 0.0f;
-                float Pitch = -11.0f;
+                Tracked<bool> Disable = false;
+                Tracked<int> AttachId = 0; // 0: Head, 1: Vehicle, 2: FPV Offset?
+                Tracked<float> FOV = 55.0f;
+                Tracked<float> OffsetHeight = -0.05f;
+                Tracked<float> OffsetForward = -0.08f;
+                Tracked<float> OffsetSide = 0.0f;
+                Tracked<float> Pitch = -11.0f;
             } Bike;
         } Camera;
     } Misc;

--- a/Gears/script.cpp
+++ b/Gears/script.cpp
@@ -584,21 +584,23 @@ void update_manual_transmission() {
     if (g_controls.ButtonJustPressed(CarControls::KeyboardControlType::DriveBiasFInc) ||
         g_controls.ButtonJustPressed(CarControls::WheelControlType::DriveBiasFInc)) {
         float bias = g_settings().DriveAssists.AWD.CustomBaseBias;
+        float customMax = g_settings().DriveAssists.AWD.CustomMax;
         bias += 0.05f;
         bias = std::clamp(
             round(bias * 20.0f) / 20.0f,
             0.01f,
-            g_settings().DriveAssists.AWD.CustomMax);
+            customMax);
         g_settings().DriveAssists.AWD.CustomBaseBias = bias;
     }
 
     if (g_controls.ButtonJustPressed(CarControls::KeyboardControlType::DriveBiasFDec) ||
         g_controls.ButtonJustPressed(CarControls::WheelControlType::DriveBiasFDec)) {
         float bias = g_settings().DriveAssists.AWD.CustomBaseBias;
+        float customMin = g_settings().DriveAssists.AWD.CustomMin;
         bias -= 0.05f;
         bias = std::clamp(
             round(bias * 20.0f) / 20.0f,
-            g_settings().DriveAssists.AWD.CustomMin,
+            customMin,
             0.99f);
         g_settings().DriveAssists.AWD.CustomBaseBias = bias;
     }
@@ -840,7 +842,8 @@ void functionHShiftTo(int i) {
 
     // shifting from neutral into gear is OK when rev matched
     float expectedRPM = g_vehData.mWheelAverageDrivenTyreSpeed / (g_vehData.mDriveMaxFlatVel / g_vehData.mGearRatios[i]);
-    bool rpmInRange = Math::Near(g_vehData.mRPM, expectedRPM, g_settings().ShiftOptions.RPMTolerance);
+    float rpmTol = g_settings().ShiftOptions.RPMTolerance;
+    bool rpmInRange = Math::Near(g_vehData.mRPM, expectedRPM, rpmTol);
 
     if (!checkShift)
         shiftPass = true;


### PR DESCRIPTION
So I found an annoying problem.

When saving the config values, it checked if a value matches the base value, and skips it when saving. This is to keep the vehicle configs clean and allow them to inherit main settings.

The issue was: Say the user has an existing config, and changes a value in game to the same value that's in the default config. This change was not saved, because the saving code sees it having the same as the main setting, and thus skips saving it.

Solution I came up with was to track all values. Seems to work well for now.